### PR TITLE
Fix to_numeric deprecation warning

### DIFF
--- a/f5_ml_pipeline/02_data_cleaning.py
+++ b/f5_ml_pipeline/02_data_cleaning.py
@@ -56,7 +56,10 @@ def clean_one_file(input_path: Path, output_path: Path) -> None:
 
     for col in df.columns:
         if col != "timestamp" and col not in ["open", "high", "low", "close", "volume"]:
-            df[col] = pd.to_numeric(df[col], errors="ignore")
+            try:
+                df[col] = pd.to_numeric(df[col])
+            except Exception:  # pragma: no cover - best effort
+                continue
             if pd.api.types.is_numeric_dtype(df[col]):
                 df[col] = df[col].astype("float32")
 


### PR DESCRIPTION
## Summary
- avoid deprecated `errors='ignore'` usage when converting columns in the data cleaning step

## Testing
- `pytest -q`