### PR TITLE
Add ML backtest step

### DIFF
--- a/doc/09_backtest.md
+++ b/doc/09_backtest.md
@@ -1,0 +1,24 @@
+# 09_backtest.py 사용법
+
+`08_predict.py`에서 생성된 `{symbol}_pred.csv`와 `04_label`의 라벨 데이터를 이용해
+매수 신호(`buy_signal==1`) 발생 시점만 진입하는 간단한 백테스트를 수행합니다.
+
+## 입력 파일
+- `ml_data/08_pred/{symbol}_pred.csv`
+- `ml_data/04_label/{symbol}_label.parquet`
+- `ml_data/04_label/{symbol}_best_params.json`
+
+## 주요 기능
+- 진입 시점의 종가를 기준으로 라벨별 예상 청산가를 계산해 수익률을 산출합니다.
+- 왕복 0.1% 수수료를 반영한 순수익률과 총수익률을 모두 기록합니다.
+- 승률, 손실률, Sharpe Ratio, 최대 낙폭(MDD) 등을 계산해 JSON 요약으로 저장합니다.
+- 각 트레이드는 CSV 파일로 기록합니다.
+
+## 출력
+- `ml_data/09_backtest/{symbol}_trades.csv`
+- `ml_data/09_backtest/{symbol}_summary.json`
+
+## 실행 방법
+```bash
+python f5_ml_pipeline/09_backtest.py
+```

--- a/doc/f5_ml_pipeline.md
+++ b/doc/f5_ml_pipeline.md
@@ -105,19 +105,17 @@ are stored in `ml_data/06_models/` using the filenames
 Run it from the repository root with `python f5_ml_pipeline/08_calibrate.py`.
 
 ## 09_backtest.py
-Performs a simple backtest using the calibrated models and test splits found in
-`ml_data/05_split/`. For each symbol and strategy pair the script:
+Uses the prediction CSV files produced by `08_predict.py` together with the
+label data under `ml_data/04_label/` to evaluate trading performance. Only rows
+where `buy_signal` equals `1` open a virtual position. The corresponding
+`label` column determines whether the trade is counted as a take profit (`1`),
+trailing stop (`2`), stop loss (`-1`) or hold (`0`).
 
-- Loads the trained model, calibration object and threshold from
-  `ml_data/06_models/`.
-- Generates probability predictions on the test set and applies the calibration
-  model and threshold to decide entry and exit signals.
-- Simulates long trades where a buy signal opens a position and a sell signal
-  closes it.
-- Writes the trade log as `{symbol}_{strategy}_trades.csv` and a KPI summary as
-  `{symbol}_{strategy}_backtest_summary.json` under `ml_data/08_metrics/`.
+For each symbol a detailed trade log `{symbol}_trades.csv` and a KPI summary
+`{symbol}_summary.json` are written under `ml_data/09_backtest/`. Metrics
+include win rate, average ROI, Sharpe ratio and maximum drawdown.
 
-Invoke the step with `python f5_ml_pipeline/09_backtest.py`.
+Run the script with `python f5_ml_pipeline/09_backtest.py`.
 =======
 # f5_ml_pipeline 구조
 

--- a/f5_ml_pipeline/09_backtest.py
+++ b/f5_ml_pipeline/09_backtest.py
@@ -1,0 +1,164 @@
+"""예측 결과와 라벨을 사용해 간단한 백테스트를 수행한다."""
+
+from __future__ import annotations
+
+import json
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from utils import ensure_dir
+
+PRED_DIR = Path("ml_data/08_pred")
+LABEL_DIR = Path("ml_data/04_label")
+OUT_DIR = Path("ml_data/09_backtest")
+LOG_PATH = Path("logs/ml_backtest.log")
+COMMISSION = 0.001  # 0.1% upbit round trip
+
+
+def setup_logger() -> None:
+    """로그 설정."""
+    ensure_dir(LOG_PATH.parent)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[
+            RotatingFileHandler(
+                LOG_PATH,
+                encoding="utf-8",
+                maxBytes=50_000 * 1024,
+                backupCount=5,
+            ),
+            logging.StreamHandler(),
+        ],
+        force=True,
+    )
+
+
+def calc_exit_price(entry: float, label: int, params: dict) -> float:
+    """라벨과 파라미터로 청산가 계산."""
+    if label == 1:
+        return entry * (1 + params.get("thresh_pct", 0))
+    if label == -1:
+        return entry * (1 - params.get("loss_pct", 0))
+    if label == 2:
+        start = params.get("trail_start_pct", 0)
+        down = params.get("trail_down_pct", 0)
+        return entry * (1 + start - down)
+    return entry
+
+
+def summarize(rois: pd.Series) -> tuple[float, float]:
+    """Sharpe ratio와 MDD 계산."""
+    sharpe = 0.0
+    if len(rois) > 1 and rois.std(ddof=0) != 0:
+        sharpe = rois.mean() / rois.std(ddof=0) * np.sqrt(len(rois))
+    equity = (1 + rois).cumprod()
+    running_max = equity.cummax()
+    drawdown = (equity - running_max) / running_max
+    mdd = float(drawdown.min()) if not drawdown.empty else 0.0
+    return float(sharpe), mdd
+
+
+def process_symbol(symbol: str) -> None:
+    """단일 심볼의 백테스트 수행."""
+    pred_path = PRED_DIR / f"{symbol}_pred.csv"
+    label_path = LABEL_DIR / f"{symbol}_label.parquet"
+    params_path = LABEL_DIR / f"{symbol}_best_params.json"
+
+    try:
+        pred_df = pd.read_csv(pred_path)
+        label_df = pd.read_parquet(label_path)
+        with open(params_path, "r", encoding="utf-8") as f:
+            params = json.load(f)
+    except Exception as exc:  # pragma: no cover - best effort
+        logging.warning("%s 로드 실패: %s", symbol, exc)
+        return
+
+    df = pd.merge(pred_df, label_df[["timestamp", "label"]], on="timestamp", how="inner")
+    if df.empty:
+        logging.warning("%s 정합성 문제: 병합 결과 0 rows", symbol)
+        return
+
+    trades = []
+    for _, row in df.iterrows():
+        if row.get("buy_signal") == 1:
+            entry_price = row["close"]
+            lbl = int(row["label"])
+            exit_price = calc_exit_price(entry_price, lbl, params)
+            gross = exit_price / entry_price - 1
+            net = gross - COMMISSION
+            trades.append({
+                "timestamp": row["timestamp"],
+                "entry_price": entry_price,
+                "label": lbl,
+                "exit_price": exit_price,
+                "gross_roi": gross,
+                "net_roi": net,
+            })
+
+    if not trades:
+        logging.info("[BACKTEST] %s 매매 없음", symbol)
+        return
+
+    trades_df = pd.DataFrame(trades)
+    tp = (trades_df["label"] == 1).sum()
+    trail = (trades_df["label"] == 2).sum()
+    sl = (trades_df["label"] == -1).sum()
+    hold = (trades_df["label"] == 0).sum()
+    win = tp + trail
+    total = len(trades_df)
+
+    sharpe, mdd = summarize(trades_df["net_roi"])
+
+    summary = {
+        "total_entries": total,
+        "tp_count": int(tp),
+        "trail_count": int(trail),
+        "sl_count": int(sl),
+        "hold_count": int(hold),
+        "win_rate": float(win / total) if total else 0.0,
+        "loss_rate": float(sl / total) if total else 0.0,
+        "avg_roi": float(trades_df["net_roi"].mean()),
+        "cum_roi": float(trades_df["net_roi"].sum()),
+        "sharpe": sharpe,
+        "mdd": mdd,
+        "avg_roi_gross": float(trades_df["gross_roi"].mean()),
+        "cum_roi_gross": float(trades_df["gross_roi"].sum()),
+    }
+
+    ensure_dir(OUT_DIR)
+    trades_path = OUT_DIR / f"{symbol}_trades.csv"
+    summary_path = OUT_DIR / f"{symbol}_summary.json"
+    trades_df.to_csv(trades_path, index=False)
+    with open(summary_path, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+
+    logging.info(
+        "[BACKTEST] %s entries=%d win_rate=%.2f%% avg_roi=%.4f sharpe=%.2f mdd=%.2f%%",
+        symbol,
+        total,
+        summary["win_rate"] * 100,
+        summary["avg_roi"],
+        summary["sharpe"],
+        summary["mdd"] * 100,
+    )
+
+
+def main() -> None:
+    """실행 엔트리 포인트."""
+    ensure_dir(PRED_DIR)
+    ensure_dir(LABEL_DIR)
+    ensure_dir(OUT_DIR)
+    setup_logger()
+
+    for file in PRED_DIR.glob("*_pred.csv"):
+        symbol = file.stem.split("_")[0]
+        process_symbol(symbol)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add standalone `09_backtest.py` to evaluate predictions vs labels
- document backtest usage in new `doc/09_backtest.md`
- update pipeline overview with new backtest description

## Testing
- `pytest -q`