### PR TITLE
Update Flask server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ Logs are written to `logs/F1-F2_loop.log`.
 Each log file automatically rotates when it exceeds 100&nbsp;MB. Previous files
 are numbered sequentially as `*.1`, `*.2`, and so on.
 
+## Running the web dashboard
+
+Launch the Flask application with:
+
+```bash
+python app.py
+```
+
+The server listens on port 3000 so you can visit `http://localhost:3000` in your browser.
+
 
 ## Credentials
 

--- a/app.py
+++ b/app.py
@@ -23,6 +23,7 @@ from f1_universe.universe_selector import (
 from f2_signal.signal_engine import reload_strategy_settings
 
 app = Flask(__name__)
+PORT = int(os.environ.get("PORT", 3000))
 
 CONFIG = load_config()
 load_universe_from_file()
@@ -509,4 +510,4 @@ if __name__ == "__main__":
         ],
         force=True,
     )
-    app.run(host="0.0.0.0", port=5000, debug=True)
+    app.run(host="0.0.0.0", port=PORT, debug=True)


### PR DESCRIPTION
## Summary
- default Flask port is now `3000`
- describe running the web dashboard in README

## Testing
- `pytest -q`