### PR TITLE
Enable optional trailing stop

### DIFF
--- a/doc/f5ml_labeling.md
+++ b/doc/f5ml_labeling.md
@@ -10,6 +10,9 @@
 
 기본값은 `horizon=30`, `thresh_pct=0.003`(0.3%)입니다.
 
+트레일링 스탑을 비활성화하려면 `trail_start_pct` 또는 `trail_down_pct` 값을
+`None`으로 설정합니다. 이 경우 라벨링과 백테스트는 단순 TP/SL 규칙만 사용합니다.
+
 ## 실행 방법
 ```bash
 python f5_ml_pipeline/04_labeling.py

--- a/tests/test_labeling.py
+++ b/tests/test_labeling.py
@@ -32,5 +32,29 @@ def test_make_labels_basic():
             "volume": [1] * 6,
         }
     )
-    result = labeling.make_labels(df, horizon=2, thresh_pct=0.003)
+    result = labeling.make_labels_basic(df, horizon=2, thresh_pct=0.003)
     assert list(result["label"]) == [1, -1, 0, 0, 0, 0]
+
+
+@pytest.mark.skipif(not pandas_available, reason="pandas not available")
+def test_trailing_none_uses_basic():
+    df = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2021-01-01", periods=6, freq="T"),
+            "open": [100] * 6,
+            "high": [100.2, 100.2, 100.4, 100.1, 100.1, 100.1],
+            "low": [100, 99, 99.8, 99.9, 99.9, 99.9],
+            "close": [100] * 6,
+            "volume": [1] * 6,
+        }
+    )
+    res_trail = labeling.make_labels_trailing(
+        df,
+        horizon=2,
+        thresh_pct=0.003,
+        loss_pct=0.003,
+        trail_start_pct=None,
+        trail_down_pct=None,
+    )
+    res_basic = labeling.make_labels_basic(df, horizon=2, thresh_pct=0.003)
+    assert list(res_trail["label"]) == list(res_basic["label"])


### PR DESCRIPTION
## Summary
- allow disabling trailing stop by passing `None`
- add `make_labels_basic` for TP/SL only
- skip trailing logic when parameters are `None`
- document how to disable trailing stop
- test trailing stop disabled path

## Testing
- `pytest -q`