### PR TITLE
Fix trailing stop on missing entry price

### DIFF
--- a/f3_order/position_manager.py
+++ b/f3_order/position_manager.py
@@ -343,10 +343,13 @@ class PositionManager:
         cur = position.get("current_price")
         if cur is None:
             return
+        entry = position.get("entry_price")
+        if entry is None:
+            return
         max_price = position.get("max_price", cur)
         start_pct = self.config.get("TRAIL_START_PCT", 0.7)
         step_pct = self.config.get("TRAIL_STEP_PCT", 1.0)
-        gain_pct = (max_price - position["entry_price"]) / position["entry_price"] * 100
+        gain_pct = (max_price - entry) / entry * 100
         if gain_pct >= start_pct:
             drop = (max_price - cur) / max_price * 100
             if drop >= step_pct:

--- a/tests/test_trailing_stop.py
+++ b/tests/test_trailing_stop.py
@@ -1,0 +1,34 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from f3_order.position_manager import PositionManager
+from f3_order.kpi_guard import KPIGuard
+from f3_order.exception_handler import ExceptionHandler
+
+
+class DummyClient:
+    def place_order(self, *args, **kwargs):
+        return {"uuid": "1", "state": "done", "side": kwargs.get("side"), "volume": kwargs.get("volume", 0)}
+
+    def get_accounts(self):
+        return []
+
+    def ticker(self, markets):
+        return [{"market": m, "trade_price": 100.0} for m in markets]
+
+
+def make_pm(tmp_path, monkeypatch):
+    monkeypatch.setattr("f3_order.position_manager.UpbitClient", lambda: DummyClient())
+    cfg = {
+        "DB_PATH": os.path.join(tmp_path, "orders.db"),
+        "POSITIONS_FILE": os.path.join(tmp_path, "pos.json"),
+    }
+    return PositionManager(cfg, {}, KPIGuard({}), ExceptionHandler({"SLIP_MAX": 0.15}))
+
+
+def test_manage_trailing_stop_missing_entry_price(tmp_path, monkeypatch):
+    pm = make_pm(tmp_path, monkeypatch)
+    position = {"symbol": "KRW-BTC", "qty": 1.0, "status": "open", "current_price": 100.0}
+    pm.manage_trailing_stop(position)
+    assert position["status"] == "open"


### PR DESCRIPTION
## Summary
- return early in `manage_trailing_stop` if entry price is missing
- add regression test to ensure trailing stop handles missing entry price

## Testing
- `pytest -q`