### PR TITLE
Improve feature set and simplify labeling config

### DIFF
--- a/doc/f5ml_feature_engineering.md
+++ b/doc/f5ml_feature_engineering.md
@@ -14,5 +14,8 @@
 - `atr14`: 14분 평균진폭
 - `vol_ratio`: 최근 거래량 대비 비율
 - `stoch_k`: 스토캐스틱 %K (14, 3)
+- `macd`, `macd_signal`, `macd_hist`: MACD(12,26,9)
+- `mfi14`: 14분 자금 흐름 지수
+- `adx14`: 14분 ADX 추세 강도
 
 실행 후 각 심볼별 `{symbol}_feature.parquet` 파일이 생성됩니다.

--- a/doc/f5ml_labeling.md
+++ b/doc/f5ml_labeling.md
@@ -8,7 +8,12 @@
 - **-1 (손절)**: 미래 `horizon` 구간에서 저가가 진입가의 `(1 - thresh_pct)` 이하이면 -1
 - **0 (중립)**: 위 두 조건을 모두 만족하지 못할 때 0
 
-기본값은 `horizon=30`, `thresh_pct=0.003`(0.3%)입니다.
+`horizon`은 기본 5분으로 고정되며, 파라미터 탐색 범위는 다음과 같습니다.
+
+- `THRESH_LIST = [0.005, 0.006, 0.007]`
+- `LOSS_LIST = [0.005, 0.006, 0.007]`
+- `TRAIL_START_LIST = [None, 0.004]`
+- `TRAIL_DOWN_LIST = [None, 0.002]`
 
 트레일링 스탑을 비활성화하려면 `trail_start_pct` 또는 `trail_down_pct` 값을
 `None`으로 설정합니다. 이 경우 라벨링과 백테스트는 단순 TP/SL 규칙만 사용합니다.

--- a/f5_ml_pipeline/03_feature_engineering.py
+++ b/f5_ml_pipeline/03_feature_engineering.py
@@ -5,6 +5,7 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 import pandas as pd
+from indicators import macd, mfi, adx
 
 from utils import ensure_dir
 
@@ -106,6 +107,16 @@ def add_features(df: pd.DataFrame) -> pd.DataFrame:
     df["bb_lower"] = ma20 - 2 * std20
     df["bb_width"] = (df["bb_upper"] - df["bb_lower"]) / ma20
     df["bb_dist"] = (df["close"] - ma20) / std20
+
+    # MACD (12, 26, 9)
+    macd_line, macd_signal, macd_hist = macd(df["close"])
+    df["macd"] = macd_line
+    df["macd_signal"] = macd_signal
+    df["macd_hist"] = macd_hist
+
+    # MFI와 ADX
+    df["mfi14"] = mfi(df["high"], df["low"], df["close"], df["volume"], period=14)
+    df["adx14"] = adx(df["high"], df["low"], df["close"], period=14)[0]
 
     # 결측치/이상치 대체
     df = df.drop(columns=["ma_vol5", "ma_vol20"], errors="ignore")

--- a/f5_ml_pipeline/06_train.py
+++ b/f5_ml_pipeline/06_train.py
@@ -27,7 +27,8 @@ FEATURES = [
     "stoch_k7", "stoch_k14",
     "pct_change_1m", "pct_change_5m", "pct_change_10m",
     "is_bull", "body_size", "body_pct", "hl_range", "oc_range",
-    "bb_upper", "bb_lower", "bb_width", "bb_dist"
+    "bb_upper", "bb_lower", "bb_width", "bb_dist",
+    "macd", "macd_signal", "macd_hist", "mfi14", "adx14"
 ]
 
 def setup_logger() -> None:

--- a/f5_ml_pipeline/07_eval.py
+++ b/f5_ml_pipeline/07_eval.py
@@ -33,7 +33,8 @@ FEATURES = [
     "stoch_k7", "stoch_k14",
     "pct_change_1m", "pct_change_5m", "pct_change_10m",
     "is_bull", "body_size", "body_pct", "hl_range", "oc_range",
-    "bb_upper", "bb_lower", "bb_width", "bb_dist"
+    "bb_upper", "bb_lower", "bb_width", "bb_dist",
+    "macd", "macd_signal", "macd_hist", "mfi14", "adx14"
 ]
 
 def setup_logger() -> None:

--- a/f5_ml_pipeline/08_predict.py
+++ b/f5_ml_pipeline/08_predict.py
@@ -25,7 +25,8 @@ FEATURES = [
     "stoch_k7", "stoch_k14",
     "pct_change_1m", "pct_change_5m", "pct_change_10m",
     "is_bull", "body_size", "body_pct", "hl_range", "oc_range",
-    "bb_upper", "bb_lower", "bb_width", "bb_dist"
+    "bb_upper", "bb_lower", "bb_width", "bb_dist",
+    "macd", "macd_signal", "macd_hist", "mfi14", "adx14"
 ]
 
 def setup_logger() -> None:


### PR DESCRIPTION
## Summary
- add MACD, MFI and ADX indicators in feature engineering
- include new features in training, evaluation and prediction steps
- narrow labeling parameter grids and fix horizon
- document new indicators and updated labeling parameters

## Testing
- `pytest -q`