### PR TITLE
Fix ML warnings

### DIFF
--- a/f5_ml_pipeline/06_train.py
+++ b/f5_ml_pipeline/06_train.py
@@ -112,8 +112,12 @@ def train_and_eval(symbol: str) -> None:
         y_valid,
         y_pred,
         output_dict=True,
+        zero_division=0,
     )
-    metrics["auc"] = roc_auc_score(y_valid, y_prob)
+    try:
+        metrics["auc"] = roc_auc_score(y_valid, y_prob)
+    except ValueError:
+        metrics["auc"] = 0.0
     metrics["label_2_support"] = int((valid_df["label"] == 2).sum())
     metrics["label_1_support"] = int((valid_df["label"] == 1).sum())
     metrics["label_-1_support"] = int((valid_df["label"] == -1).sum())

--- a/f5_ml_pipeline/07_eval.py
+++ b/f5_ml_pipeline/07_eval.py
@@ -79,8 +79,12 @@ def evaluate(symbol: str) -> None:
         y_true,
         y_pred,
         output_dict=True,
+        zero_division=0,
     )
-    metrics["auc"] = roc_auc_score(y_true, y_prob)
+    try:
+        metrics["auc"] = roc_auc_score(y_true, y_prob)
+    except ValueError:
+        metrics["auc"] = 0.0
     metrics["brier"] = brier_score_loss(y_true, y_prob)
     metrics["pr_auc"] = average_precision_score(y_true, y_prob)
 


### PR DESCRIPTION
## Summary
- avoid zero division warnings during training and evaluation

## Testing
- `pytest -q`