### PR TITLE
Handle object columns in eval

### DIFF
--- a/f5_ml_pipeline/07_eval.py
+++ b/f5_ml_pipeline/07_eval.py
@@ -66,6 +66,12 @@ def evaluate(symbol: str) -> None:
     for f in features:
         if f not in test_df.columns:
             test_df[f] = 0
+
+    for col in test_df.columns:
+        if test_df[col].dtype == "object":
+            converted = pd.to_numeric(test_df[col], errors="coerce")
+            if pd.api.types.is_numeric_dtype(converted):
+                test_df[col] = converted
     test_df.fillna(0, inplace=True)
 
     X_test = test_df[features]

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,0 +1,67 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+import pytest
+
+try:
+    import pandas as pd
+    pandas_available = True
+except Exception:  # pragma: no cover - pandas missing
+    pandas_available = False
+
+
+@pytest.mark.skipif(not pandas_available, reason="pandas not available")
+def test_evaluate_converts_object_columns(tmp_path):
+    # Provide dummy joblib implementation
+    import pickle
+
+    dummy_joblib = types.ModuleType("joblib")
+
+    def dump(obj, path):
+        with open(path, "wb") as f:
+            pickle.dump(obj, f)
+
+    def load(path):
+        with open(path, "rb") as f:
+            return pickle.load(f)
+
+    dummy_joblib.dump = dump
+    dummy_joblib.load = load
+    sys.modules["joblib"] = dummy_joblib
+
+    module_path = Path(__file__).resolve().parents[1] / "f5_ml_pipeline" / "07_eval.py"
+    spec = importlib.util.spec_from_file_location("eval_mod", module_path)
+    eval_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(eval_mod)
+
+    split_dir = tmp_path / "05_split"
+    model_dir = tmp_path / "06_models"
+    eval_dir = tmp_path / "07_eval"
+    for d in (split_dir, model_dir, eval_dir):
+        d.mkdir()
+
+    class DummyModel:
+        feature_names_in_ = ["feat1", "feat2"]
+
+        def predict(self, X):
+            return (X.sum(axis=1) > 1).astype(int).to_numpy()
+
+        def predict_proba(self, X):
+            prob = X.sum(axis=1) / 2
+            prob = prob.clip(0, 1)
+            return pd.concat([1 - prob, prob], axis=1).to_numpy()
+
+    model = DummyModel()
+    dummy_joblib.dump(model, model_dir / "AAA_model.pkl")
+
+    df = pd.DataFrame({"feat1": ["0.6", "0.4"], "feat2": ["0.5", "0.2"], "label": [1, 0]})
+    df.to_parquet(split_dir / "AAA_test.parquet")
+
+    eval_mod.SPLIT_DIR = split_dir
+    eval_mod.MODEL_DIR = model_dir
+    eval_mod.EVAL_DIR = eval_dir
+
+    eval_mod.evaluate("AAA")
+
+    assert (eval_dir / "AAA_metrics.json").exists()


### PR DESCRIPTION
## Summary
- convert object columns to numeric during evaluation
- test that evaluation handles object-typed columns

## Testing
- `pytest -q`