### PR TITLE
Ensure empty selections reset output files

### DIFF
--- a/doc/f5ml_10_select_best_strategies.md
+++ b/doc/f5ml_10_select_best_strategies.md
@@ -20,6 +20,9 @@
 변경 사항은 `logs/select_best_strategies.log` 파일에도 기록되어
 모니터링 목록 갱신 여부를 확인할 수 있습니다.
 
+조건을 만족하는 전략이 하나도 없으면 두 파일은 빈 리스트 `[]`로 덮어써
+이전 결과가 남지 않도록 합니다.
+
 ## 실행 방법
 ```bash
 python f5_ml_pipeline/10_select_best_strategies.py

--- a/f5_ml_pipeline/10_select_best_strategies.py
+++ b/f5_ml_pipeline/10_select_best_strategies.py
@@ -106,6 +106,13 @@ def save_monitoring_list(symbols: list[str]) -> None:
         logging.error("monitoring list 저장 실패: %s", exc)
 
 
+def write_json(path: Path, data: list[dict]) -> None:
+    """Write data to JSON file, clearing existing contents."""
+    ensure_dir(path.parent)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
 def main() -> None:
     """실행 엔트리 포인트."""
     ensure_dir(SUMMARY_DIR)
@@ -114,13 +121,14 @@ def main() -> None:
     setup_logger()
 
     selected = select_strategies()
-    with open(OUT_FILE, "w", encoding="utf-8") as f:
-        json.dump(selected, f, indent=2)
+    write_json(OUT_FILE, selected)
 
     symbols = [s.get("symbol") for s in selected if s.get("symbol")]
     save_monitoring_list(symbols)
 
     logging.info("[SELECT] %d strategies saved", len(selected))
+    if not selected:
+        logging.info("[SELECT] no strategies met criteria; files cleared")
 
 
 if __name__ == "__main__":

--- a/tests/test_select_best_strategies.py
+++ b/tests/test_select_best_strategies.py
@@ -87,3 +87,28 @@ def test_main_writes_monitoring(tmp_path):
 
     log_text = (tmp_path / "select.log").read_text()
     assert "monitoring list updated" in log_text
+
+
+def test_main_clears_files_when_empty(tmp_path):
+    summary_dir = tmp_path / "09_backtest"
+    param_dir = tmp_path / "04_label"
+    out_dir = tmp_path / "10_selected"
+    conf_dir = tmp_path / "config"
+    summary_dir.mkdir()
+    param_dir.mkdir()
+    out_dir.mkdir()
+    conf_dir.mkdir()
+
+    select_best.SUMMARY_DIR = summary_dir
+    select_best.PARAM_DIR = param_dir
+    select_best.OUT_DIR = out_dir
+    select_best.OUT_FILE = out_dir / "selected_strategies.json"
+    select_best.MONITORING_LIST_FILE = conf_dir / "coin_list_monitoring.json"
+    select_best.LOG_PATH = tmp_path / "select.log"
+
+    select_best.main()
+
+    out_data = json.loads((out_dir / "selected_strategies.json").read_text())
+    mon_data = json.loads((conf_dir / "coin_list_monitoring.json").read_text())
+    assert out_data == []
+    assert mon_data == []


### PR DESCRIPTION
## Summary
- add write_json helper to overwrite selection output file
- clear selected files and log when no strategies meet criteria
- test that empty results produce empty output files
- document behavior in pipeline docs

## Testing
- `pytest -q`