### PR TITLE
Handle numeric strings in strategy selection

### DIFF
--- a/doc/f5ml_10_select_best_strategies.md
+++ b/doc/f5ml_10_select_best_strategies.md
@@ -20,6 +20,9 @@
 변경 사항은 `logs/select_best_strategies.log` 파일에도 기록되어
 모니터링 목록 갱신 여부를 확인할 수 있습니다.
 
+조건을 만족하는 전략이 하나도 없으면 두 파일은 빈 리스트 `[]`로 덮어써
+이전 결과가 남지 않도록 합니다.
+
 ## 실행 방법
 ```bash
 python f5_ml_pipeline/10_select_best_strategies.py

--- a/tests/test_select_best_strategies.py
+++ b/tests/test_select_best_strategies.py
@@ -26,6 +26,17 @@ def test_passes_criteria_basic():
     assert select_best.passes_criteria(summary)
 
 
+def test_passes_criteria_with_str_values():
+    summary = {
+        "win_rate": "0.6",
+        "avg_roi": "0.003",
+        "sharpe": "1.2",
+        "mdd": "-0.05",
+        "total_entries": "60",
+    }
+    assert select_best.passes_criteria(summary)
+
+
 def test_select_strategies(tmp_path):
     summary_dir = tmp_path / "09_backtest"
     param_dir = tmp_path / "04_label"
@@ -87,3 +98,28 @@ def test_main_writes_monitoring(tmp_path):
 
     log_text = (tmp_path / "select.log").read_text()
     assert "monitoring list updated" in log_text
+
+
+def test_main_clears_files_when_empty(tmp_path):
+    summary_dir = tmp_path / "09_backtest"
+    param_dir = tmp_path / "04_label"
+    out_dir = tmp_path / "10_selected"
+    conf_dir = tmp_path / "config"
+    summary_dir.mkdir()
+    param_dir.mkdir()
+    out_dir.mkdir()
+    conf_dir.mkdir()
+
+    select_best.SUMMARY_DIR = summary_dir
+    select_best.PARAM_DIR = param_dir
+    select_best.OUT_DIR = out_dir
+    select_best.OUT_FILE = out_dir / "selected_strategies.json"
+    select_best.MONITORING_LIST_FILE = conf_dir / "coin_list_monitoring.json"
+    select_best.LOG_PATH = tmp_path / "select.log"
+
+    select_best.main()
+
+    out_data = json.loads((out_dir / "selected_strategies.json").read_text())
+    mon_data = json.loads((conf_dir / "coin_list_monitoring.json").read_text())
+    assert out_data == []
+    assert mon_data == []


### PR DESCRIPTION
## Summary
- make passes_criteria robust to numeric strings
- test numeric string handling for criteria

## Testing
- `pytest -q`