### PR TITLE
Document buy signal log

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ python signal_loop.py
 Logs are written to `logs/F1-F2_loop.log`.
 Each log file automatically rotates when it exceeds 100&nbsp;MB. Previous files
 are numbered sequentially as `*.1`, `*.2`, and so on.
+To run the standalone ML buy signal routine:
+```bash
+python f2_ml_buy_signal/f2_ml_buy_signal.py
+```
+Results are logged to `logs/f2_ml_buy_signal.log`.
+
 
 ## Running the web dashboard
 

--- a/doc/02_coin_buy_logic.md
+++ b/doc/02_coin_buy_logic.md
@@ -37,6 +37,7 @@
 - `SPREAD_TH` – 스프레드 임계값. 이보다 좁으면 바로 시장가 주문
 
 위 값들은 `config/setting_date/Latest_config.json` 또는 기타 설정 파일에서 관리됩니다.【F:config/setting_date/Latest_config.json†L1-L23】
+매수 신호 계산 과정과 결과는 `logs/f2_ml_buy_signal.log`에 기록됩니다.
 
 ## 동작 흐름
 1. `signal_loop.py`의 `process_symbol`에서 각 심볼의 OHLCV 데이터를 받아 `f2_signal`을 호출합니다.


### PR DESCRIPTION
## Summary
- explain how to run the F2 ML buy signal script
- note that it logs to `logs/f2_ml_buy_signal.log`
- clarify where the log file is written in the buy logic doc

## Testing
- `pytest -q`