### PR TITLE
Implement buy/sell list tracking

### DIFF
--- a/doc/02_coin_buy_logic.md
+++ b/doc/02_coin_buy_logic.md
@@ -21,7 +21,7 @@
     "sell_triggers": []
 }
 ```
-매수 조건이 충족되면 `buy_signal`이 `True`가 됩니다. 별도의 `f2_ml_buy_signal.run()` 함수가 `coin_list_monitoring.json`에 있는 종목을 순회하면서 이 값을 확인하고, `config/coin_realtime_buy_list.json`에 매수 대상 코인을 기록합니다.【F:f2_ml_buy_signal/f2_ml_buy_signal.py†L117-L135】
+매수 조건이 충족되면 `buy_signal`이 `True`가 됩니다. 별도의 `f2_ml_buy_signal.run()` 함수가 `coin_list_monitoring.json`에 있는 종목을 순회하면서 이 값을 확인하고, `config/coin_realtime_buy_list.json`에 매수 대상을 `{심볼: 0}` 형식으로 추가합니다. 동일 심볼이 이미 존재하면 값은 유지됩니다. 아울러 손절/익절/트레일링 스탑 설정은 `coin_realtime_sell_list.json`에 함께 저장됩니다.【F:f2_ml_buy_signal/f2_ml_buy_signal.py†L221-L259】
 
 
 ### `OrderExecutor.entry(signal)`

--- a/f2_ml_buy_signal/f2_ml_buy_signal.py
+++ b/f2_ml_buy_signal/f2_ml_buy_signal.py
@@ -49,6 +49,21 @@ SPLIT_DIR = DATA_ROOT / "05_data"
 MODEL_DIR = DATA_ROOT / "06_data"
 
 
+def _load_json(path: Path):
+    if not path.exists():
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def _save_json(path: Path, data) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
 def fetch_ohlcv(symbol: str, count: int = 60) -> pd.DataFrame:
     """Fetch recent OHLCV data with retries."""
     logging.info("[FETCH] %s count=%d", symbol, count)
@@ -210,17 +225,35 @@ def run() -> List[str]:
             coins = json.load(f)
     except Exception:
         coins = []
-    
+
     logging.info("[RUN] coins=%s", coins)
+    buy_list_path = CONFIG_DIR / "coin_realtime_buy_list.json"
+    sell_list_path = CONFIG_DIR / "coin_realtime_sell_list.json"
+    buy_dict = _load_json(buy_list_path)
+    sell_dict = _load_json(sell_list_path)
+    risk_cfg = _load_json(CONFIG_DIR / "risk.json")
+
     results = []
     for sym in coins:
         buy = check_buy_signal(sym)
         logging.info("[%s] buy_signal=%s", sym, int(buy))
         if buy:
             results.append(sym)
+            if sym not in buy_dict:
+                buy_dict[sym] = 0
+                sell_dict.setdefault(
+                    sym,
+                    {
+                        "SL_PCT": risk_cfg.get("SL_PCT"),
+                        "TP_PCT": risk_cfg.get("TP_PCT"),
+                        "TRAILING_STOP_ENABLED": risk_cfg.get("TRAILING_STOP_ENABLED"),
+                        "TRAIL_START_PCT": risk_cfg.get("TRAIL_START_PCT"),
+                        "TRAIL_STEP_PCT": risk_cfg.get("TRAIL_STEP_PCT"),
+                    },
+                )
 
-    with open(CONFIG_DIR / "coin_realtime_buy_list.json", "w", encoding="utf-8") as f:
-        json.dump(results, f, ensure_ascii=False, indent=2)
+    _save_json(buy_list_path, buy_dict)
+    _save_json(sell_list_path, sell_dict)
 
     logging.info("[RUN] finished. %d coins to buy", len(results))
     return results

--- a/tests/test_ml_buy_list.py
+++ b/tests/test_ml_buy_list.py
@@ -1,0 +1,62 @@
+import json
+import os
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+class Dummy:
+    def __init__(self, result):
+        self.result = result
+    def __call__(self, symbol):
+        return self.result
+
+
+def test_run_updates_buy_and_sell_lists(tmp_path, monkeypatch):
+    cfg = tmp_path
+    (cfg / "coin_list_monitoring.json").write_text(json.dumps(["KRW-AAA", "KRW-BBB"]))
+    (cfg / "coin_realtime_buy_list.json").write_text(json.dumps({"KRW-AAA": 1}))
+    (cfg / "coin_realtime_sell_list.json").write_text(json.dumps({"KRW-AAA": {"SL_PCT": 1}}))
+    (cfg / "risk.json").write_text(json.dumps({
+        "SL_PCT": 1.0,
+        "TP_PCT": 2.0,
+        "TRAILING_STOP_ENABLED": True,
+        "TRAIL_START_PCT": 0.5,
+        "TRAIL_STEP_PCT": 1.0
+    }))
+
+    # Stub optional dependencies before importing module
+    pandas_stub = types.ModuleType("pandas")
+    pandas_stub.Series = object
+    pandas_stub.DataFrame = object
+    sklearn_stub = types.ModuleType("sklearn")
+    linear_stub = types.ModuleType("sklearn.linear_model")
+    linear_stub.LogisticRegression = object
+    joblib_stub = types.ModuleType("joblib")
+    joblib_stub.dump = lambda *a, **k: None
+    joblib_stub.load = lambda *a, **k: None
+    numpy_stub = types.ModuleType("numpy")
+    sys.modules.update({
+        "pandas": pandas_stub,
+        "sklearn": sklearn_stub,
+        "sklearn.linear_model": linear_stub,
+        "joblib": joblib_stub,
+        "numpy": numpy_stub,
+        "pyupbit": types.ModuleType("pyupbit"),
+    })
+
+    from f2_ml_buy_signal import f2_ml_buy_signal as ml
+
+    monkeypatch.setattr(ml, "CONFIG_DIR", Path(cfg))
+    monkeypatch.setattr(ml, "check_buy_signal", Dummy(True))
+
+    result = ml.run()
+    buy = json.loads((cfg / "coin_realtime_buy_list.json").read_text())
+    sell = json.loads((cfg / "coin_realtime_sell_list.json").read_text())
+
+    assert "KRW-BBB" in buy and buy["KRW-BBB"] == 0
+    assert "KRW-BBB" in sell
+    assert result == ["KRW-AAA", "KRW-BBB"]
+


### PR DESCRIPTION
## Summary
- extend `f2_ml_buy_signal.run` to preserve previous entries and create sell list
- document the new behaviour in the coin buy logic docs
- add regression test covering buy/sell list updates

## Testing
- `pytest -q`