### PR TITLE
Fix path handling in ML pipeline

### DIFF
--- a/doc/f5ml_05_split.md
+++ b/doc/f5ml_05_split.md
@@ -9,3 +9,6 @@
 ```bash
 python f5_ml_pipeline/05_split.py
 ```
+
+경로는 스크립트 위치를 기준으로 계산되므로 현재 작업 디렉터리와 상관없이
+동일한 폴더 구조(`ml_data/04_label/`, `ml_data/05_split/`)에 결과가 저장됩니다.

--- a/doc/f5ml_06_train.md
+++ b/doc/f5ml_06_train.md
@@ -15,6 +15,10 @@ LightGBM 분류 모델을 학습하고 `ml_data/06_models/`에 저장합니다.
 python f5_ml_pipeline/06_train.py
 ```
 
+모델과 로그 파일 위치는 스크립트 기준으로 결정되므로, 어디서 실행하더라도
+`ml_data/05_split/`에서 학습 데이터를 읽고 `ml_data/06_models/`에 결과를 저장합
+니다.
+
 모델 학습 파라미터는 `f5_ml_pipeline/config/train_config.yaml`에서 관리합니다.
 외부 패키지 없이 간단한 YAML 파서를 내장해 의존성을 최소화했으며
 `n_estimators`와 `early_stopping_rounds` 값 등을 바꿔 자유롭게 실험할 수 있습니다.

--- a/f2_ml_buy_signal/f2_ml_buy_signal.py
+++ b/f2_ml_buy_signal/f2_ml_buy_signal.py
@@ -220,6 +220,8 @@ def check_buy_signal_df(df: pd.DataFrame, symbol: str = "df") -> bool:
 
 def run() -> List[str]:
     logging.info("[RUN] starting buy signal scan")
+    logging.info("[SETUP] DATA_ROOT=%s", DATA_ROOT)
+    logging.info("[SETUP] MODEL_DIR=%s", MODEL_DIR)
     try:
         with open(CONFIG_DIR / "coin_list_monitoring.json", "r", encoding="utf-8") as f:
             coins = json.load(f)

--- a/f5_ml_pipeline/05_split.py
+++ b/f5_ml_pipeline/05_split.py
@@ -10,10 +10,12 @@ import pandas as pd
 
 from utils import ensure_dir
 
-
-LABEL_DIR = Path("ml_data/04_label")
-SPLIT_DIR = Path("ml_data/05_split")
-LOG_PATH = Path("logs/ml_split.log")
+# Absolute paths relative to this file so the script behaves the same
+# regardless of the current working directory.
+ROOT_DIR = Path(__file__).resolve().parent
+LABEL_DIR = ROOT_DIR / "ml_data" / "04_label"
+SPLIT_DIR = ROOT_DIR / "ml_data" / "05_split"
+LOG_PATH = ROOT_DIR / "logs" / "ml_split.log"
 
 
 def setup_logger() -> None:
@@ -84,6 +86,8 @@ def main(train_ratio: float = 0.7, valid_ratio: float = 0.2) -> None:
     ensure_dir(LABEL_DIR)
     ensure_dir(SPLIT_DIR)
     setup_logger()
+    logging.info("[SETUP] LABEL_DIR=%s", LABEL_DIR)
+    logging.info("[SETUP] SPLIT_DIR=%s", SPLIT_DIR)
 
     for file in LABEL_DIR.glob("*.parquet"):
         process_file(file, train_ratio, valid_ratio)

--- a/f5_ml_pipeline/06_train.py
+++ b/f5_ml_pipeline/06_train.py
@@ -14,9 +14,12 @@ from sklearn.metrics import classification_report, roc_auc_score
 
 from utils import ensure_dir, load_yaml_config
 
-SPLIT_DIR = Path("ml_data/05_split")
-MODEL_DIR = Path("ml_data/06_models")
-LOG_PATH = Path("logs/ml_train.log")
+# Use absolute paths relative to this file so execution works regardless of
+# the current working directory.
+ROOT_DIR = Path(__file__).resolve().parent
+SPLIT_DIR = ROOT_DIR / "ml_data" / "05_split"
+MODEL_DIR = ROOT_DIR / "ml_data" / "06_models"
+LOG_PATH = ROOT_DIR / "logs" / "ml_train.log"
 CONFIG_PATH = Path(__file__).parent / "config" / "train_config.yaml"
 CONFIG = load_yaml_config(CONFIG_PATH)
 
@@ -141,7 +144,9 @@ def main() -> None:
     ensure_dir(SPLIT_DIR)
     ensure_dir(MODEL_DIR)
     setup_logger()
-
+    logging.info("[SETUP] SPLIT_DIR=%s", SPLIT_DIR)
+    logging.info("[SETUP] MODEL_DIR=%s", MODEL_DIR)
+    
     for file in SPLIT_DIR.glob("*_train.parquet"):
         symbol = file.stem.split("_")[0]
         train_and_eval(symbol)


### PR DESCRIPTION
## Summary
- ensure `05_split.py` and `06_train.py` use paths relative to their location
- log the data/model directories at startup
- show data and model roots in `f2_ml_buy_signal`
- document new path behavior in docs

## Testing
- `pytest -q`