### PR TITLE
Improve beginner documentation

### DIFF
--- a/doc/01_select_universe.md
+++ b/doc/01_select_universe.md
@@ -1,68 +1,56 @@
-# 유니버스 선정 개편안
+# 유니버스 결정 절차
 
-이 문서는 새롭게 구성될 **F1 모듈**의 코인 필터링 과정을 정리한 초안입니다. 앞으로 웹
-대시보드와 연계해 모니터링 대상 코인과 머신러닝 학습용 코인을 쉽게 관리하려는 목적이
-있습니다.
+이 문서는 F1 모듈이 어떤 방식으로 매매 대상 코인 목록(유니버스)을
+결정하는지 단계별로 설명합니다. 초보 기획자가 읽어도 이해할 수 있도록
+관련 파일과 동작 흐름을 간단하게 정리했습니다.
 
-## 1. 모니터링 대상 코인 선택
+## 핵심 역할
 
-1. ML 파이프라인의 결과물인 `f5_ml_pipeline/ml_data/10_selected/selected_strategies.json`
-   파일에 `symbol` 목록이 존재하면 이를 우선 사용합니다.
-2. 사용자는 웹 화면에서 각 코인을 **허용** 또는 **미허용**으로 지정할 수 있습니다.
-   - 메뉴 예시: "매수대상 코인선정".
-3. 허용된 코인만 실제 모니터링 대상(유니버스)으로 채택됩니다.
+- **모니터링 대상**을 정해 F2/F3가 실시간으로 다룰 코인을 제한합니다.
+- **데이터 수집 대상**을 정해 F5 머신러닝 학습을 위한 데이터를 모읍니다.
 
-## 2. 데이터 수집용 코인 필터링
+주요 코드는 `f1_universe/universe_selector.py`에 있으며 주기적으로
+`config/current_universe.json`에 결과를 저장합니다.
 
-웹 메뉴 "데이터 수집 코인선정"에서 다음 조건을 입력받습니다.
+## 사용되는 파일
 
-```json
-{
-  "min_price": 700.0,
-  "max_price": 23000.0,
-  "volume_rank": 30,
-  "min_24h_trade_price": 1000000000.0
-}
-```
+| 파일 | 설명 |
+| ---- | ---- |
+| `config/coin_list_monitoring.json` | 실전 모니터링에 사용할 코인 목록. 빈 배열이면 다른 데이터로 대체됩니다. |
+| `f5_ml_pipeline/ml_data/10_selected/selected_strategies.json` | ML 백테스트 결과로 뽑힌 우수 코인 목록. `coin_list_monitoring.json`이 비어 있을 때 우선 사용됩니다. |
+| `config/universe.json` | 가격, 거래량 등 기본 필터 조건. |
+| `config/coin_list_data_collection.json` | 학습용 데이터를 수집할 코인 목록. |
+| `config/filter_coin_data_collection.json` | 데이터 수집 시 적용할 가격·거래량 조건. |
+| `config/current_universe.json` | 마지막으로 선택된 유니버스가 기록되는 파일. |
 
-이 조건에 맞는 모든 코인에 대해 1분 주기로 데이터를 수집합니다.
+로그는 `logs/F1_signal_engine.log`와 `logs/F1-F2_loop.log`에 저장됩니다.
 
-## 3. 수집 데이터 종류
+## 주요 함수
 
-- **1분봉(OHLCV)**: 시장, UTC/KST 시각, 시가, 고가, 저가, 종가, 누적 거래대금 등
-- **호가(Orderbook)**: 매수/매도 호가 15단계와 잔량 정보
-- **체결(Trades)**: 체결 시각, 가격, 수량, 체결 ID 등
-- **시세(Ticker)**: 실시간 가격, 변동률, 24시간 거래량 등
+- `load_monitoring_coins()` – 모니터링 목록을 읽어 리스트로 반환합니다.
+- `load_selected_universe()` – ML 파이프라인에서 선별한 목록을 읽어옵니다.
+- `select_universe()` – 위 두 목록을 순서대로 확인한 뒤 없으면
+  `load_universe_from_file()` 결과를 사용합니다.
+- `update_universe()` – 선택된 유니버스를 메모리와 `current_universe.json`에 갱신합니다.
+- `schedule_universe_updates()` – 주기적으로 `update_universe()`를 호출하는 백그라운드 스레드를 시작합니다.
 
-## 4. 활용 목적
+## 동작 흐름
 
-1. **모니터링용 데이터**
-   - `selected_strategies.json`에서 선택된 코인에 한해 매수/매도 모니터링에 활용합니다.
-2. **머신러닝 학습 데이터**
-   - `03_feature_engineering.py`에서 기술적 지표 계산에 사용됩니다.
-   - `04_labeling.py`에서 매매 신호 라벨을 생성할 때 참조합니다.
+1. **전략 선별(F5 모듈)**
+   - `f5_ml_pipeline/10_select_best_strategies.py`가 백테스트 결과를 평가하여
+     좋은 심볼을 `config/coin_list_monitoring.json`에 저장합니다.
+2. **유니버스 로드**
+   - `signal_loop.py` 실행 시 `schedule_universe_updates()`가 동작하여
+     30분마다 `select_universe()`를 호출합니다.
+   - `select_universe()`는 `coin_list_monitoring.json` → `selected_strategies.json`
+     → `current_universe.json` 순으로 확인해 첫 번째로 발견된 리스트를 사용합니다.
+3. **파일 갱신**
+   - 결정된 유니버스는 `config/current_universe.json`에 기록되어
+     다른 모듈이 동일한 목록을 참조할 수 있게 합니다.
+4. **데이터 수집**
+   - 별도로 실행되는 `f5_ml_pipeline/01_data_collect.py`는
+     `coin_list_data_collection.json`과 `filter_coin_data_collection.json`을 읽어
+     학습용 데이터를 수집합니다.
 
-## 5. 설정 파일 구조
-
-- `config/coin_list_monitoring.json` – 웹에서 허용으로 지정한 모니터링 대상 코인 리스트
-- `config/coin_list_data_collection.json` – 데이터 수집에 사용할 코인 리스트
-- `config/filter_coin_data_collection.json` – 데이터 수집 조건 값
-- `f5_ml_pipeline/ml_data/10_selected/selected_strategies.json` – ML에서 추린 후보 목록
-
-### 예시 JSON 구조
-
-두 코인 리스트 파일은 아래와 같이 심볼 문자열 배열을 저장합니다.
-
-```json
-[
-    "KRW-BTC",
-    "KRW-ETH",
-    "KRW-XRP"
-]
-```
-
-## 추가
-
-- 데이터 수집 스케줄은 코인 수가 많아질수록 부하가 커지므로 1분 간격 작업이 겹치지 않게 스레드 풀이나 비동기 방식을 고려합니다.
-- 웹 대시보드는 단순 토글만 제공하고 실제 저장은 JSON 파일로 관리하면 버전 관리가 용이합니다.
-
+이 구조를 통해 모니터링 대상과 학습용 대상이 분리되며,
+웹 대시보드나 ML 파이프라인 결과에 따라 유니버스가 자동으로 업데이트됩니다.

--- a/doc/04_risk_logic.md
+++ b/doc/04_risk_logic.md
@@ -1,12 +1,17 @@
 # 리스크 관리 로직
 
-이 문서는 F4 모듈에서 계좌 손익과 시스템 상태를 감시하여 자동으로 매매를 제어하는 방법을 설명합니다. `RiskManager`는 모든 포지션을 통제하며 일시 중단(PAUSE)이나 전면 중단(HALT)을 결정합니다.
+이 문서는 **F4 리스크 매니저**가 계좌 손익과 시스템 상태를 어떻게 감시하고
+매매를 제어하는지 초보 기획자도 이해하기 쉽도록 설명합니다.
+`RiskManager` 클래스는 모든 포지션을 통제하며 일시 중단(PAUSE)이나
+전면 중단(HALT)을 결정합니다.
 
 ## 관련 파일
 - `f4_riskManager/risk_manager.py` – 리스크 FSM과 핵심 로직을 포함한 `RiskManager`
 - `f4_riskManager/risk_config.py` – 설정 파일을 읽어들이는 `RiskConfig`
 - `f4_riskManager/risk_logger.py` – 상태 변화 및 이벤트를 DB와 로그 파일에 기록
 - `f4_riskManager/risk_utils.py` – 공용 유틸과 상태 정의
+
+로그 파일은 `logs/F4_risk_manager.log`와 `logs/risk_fsm.log`에 저장됩니다.
 
 ## 주요 함수와 변수
 
@@ -50,5 +55,6 @@
 2. `RiskManager.periodic()`이 호출되어 설정 파일 변경 여부를 체크하고 `check_risk`를 실행합니다.
 3. 손실 한도 초과 또는 슬리피지 이벤트가 발생하면 `pause` 또는 `disable_symbol`을 통해 신규 진입을 막고 필요 시 포지션을 강제 청산합니다.
 4. 치명적인 손실이 발생하거나 MDD 한도가 초과되면 `halt`가 호출되어 모든 매매가 중단됩니다.
+5. 상태 전이는 `risk_fsm.log`에 기록되며 주요 이벤트는 `RiskLogger`를 통해 로그 파일과 Telegram 알림으로 전송됩니다.
 
 `RiskManager`를 통해 시스템은 예상치 못한 손실을 빠르게 제한하고 안정적으로 운용될 수 있습니다.

--- a/doc/f5ml_01_data_collect.md
+++ b/doc/f5ml_01_data_collect.md
@@ -1,14 +1,24 @@
 # F5ML_01_data_collect.py 사용법
 
-`coin_list_data_collection.json` 파일에 지정된 코인 목록을 대상으로 1분 간격으로
-OHLCV, 호가, 체결, 시세 데이터를 수집합니다. 결과 Parquet 파일은
-`f5_ml_pipeline/ml_data/01_raw/<데이터종류>/` 폴더에 저장됩니다.
+`coin_list_data_collection.json`에 명시된 코인들을 매 분마다 호출하여
+OHLCV, 호가, 체결, 시세 데이터를 수집합니다.
+수집된 데이터는 `f5_ml_pipeline/ml_data/01_raw/<데이터종류>/` 폴더에
+Parquet 형식으로 저장됩니다.
 
 ## 주요 기능
 - 코인 리스트를 읽어 매 분 정각 이후 5초가 지난 시점에 데이터를 요청합니다.
 - 기존 파일이 있으면 데이터를 누적 저장하며 `timestamp`와 `market` 등을 기준으로
   중복을 제거합니다.
 - 오류나 누락 내역은 `logs/data_collect.log`에 기록됩니다.
+
+모니터링할 코인 목록은 `config/coin_list_data_collection.json`에 저장되며,
+로그 파일은 `f5_ml_pipeline/logs/data_collect.log`로 분리되어 보관됩니다.
+
+### 코드 구조
+- `load_coin_list()` – 수집 대상 코인을 불러옵니다.【F:f5_ml_pipeline/01_data_collect.py†L57-L68】
+- `collect_once()` – 한 번 실행으로 OHLCV, 호가 등 네 종류의 데이터를 모두 수집합니다.【F:f5_ml_pipeline/01_data_collect.py†L152-L177】
+- `next_minute()` – 다음 분 시작 시각을 계산해 루프 타이밍을 맞춥니다.【F:f5_ml_pipeline/01_data_collect.py†L180-L183】
+- `main()` – 무한 루프를 돌며 `collect_once()`를 호출합니다.【F:f5_ml_pipeline/01_data_collect.py†L186-L213】
 
 다음과 같이 실행할 수 있습니다.
 ```bash

--- a/doc/f5ml_05_split.md
+++ b/doc/f5ml_05_split.md
@@ -3,7 +3,13 @@
 `f5_ml_pipeline/ml_data/04_label/` 폴더의 라벨 데이터를 읽어 시간순으로 학습, 검증, 테스트 세트로 분할합니다.
 결과는 `f5_ml_pipeline/ml_data/05_split/`에 `{symbol}_train.parquet`, `{symbol}_valid.parquet`, `{symbol}_test.parquet` 형식으로 저장됩니다.
 
-기본 분할 비율은 학습 70%, 검증 20%, 테스트 10%이며, 필요한 경우 코드 상에서 비율을 변경할 수 있습니다.
+기본 분할 비율은 학습 70%, 검증 20%, 테스트 10%이며 필요에 따라 인자를 조정할 수 있습니다.
+
+### 코드 구조
+- `time_split()` – 데이터프레임을 시간순으로 나눠 세 개의 데이터프레임을 반환합니다.【F:f5_ml_pipeline/05_split.py†L40-L50】
+- `process_file()` – 단일 파일을 읽어 `time_split()` 후 결과를 저장합니다.【F:f5_ml_pipeline/05_split.py†L53-L81】
+- `main()` – `04_label` 폴더의 모든 Parquet 파일에 대해 반복 호출합니다.【F:f5_ml_pipeline/05_split.py†L84-L97】
+로그는 `f5_ml_pipeline/logs/ml_split.log`에 남습니다.
 
 ## 실행 방법
 ```bash

--- a/doc/f5ml_06_train.md
+++ b/doc/f5ml_06_train.md
@@ -1,14 +1,18 @@
 # F5ML_06_train.py 사용법
 
-`f5_ml_pipeline/ml_data/05_split/`에 저장된 학습/검증 데이터를 읽어
+`f5_ml_pipeline/ml_data/05_split/` 폴더에 있는 학습/검증 데이터를 읽어
 LightGBM 분류 모델을 학습하고 `f5_ml_pipeline/ml_data/06_models/`에 저장합니다.
-모델 학습 시 사용되는 피처 목록은 데이터에 존재하는 모든 컬럼에서
-`timestamp`와 `label`을 제외한 값으로 자동 결정됩니다.
+학습에 사용되는 피처는 모든 컬럼에서 `timestamp`와 `label`을 제외한 값으로
+자동 결정됩니다.
 
 ## 주요 기능
 - EMA, RSI, ATR 등 주요 지표를 피처로 사용합니다.
 - 라벨 1을 매수 신호로 간주하여 이진 분류 모델을 학습합니다.
 - 검증 데이터로 정확도, F1 점수, AUC 등을 계산하여 `*_metrics.json`에 기록합니다.
+
+### 코드 구조
+- `train_and_eval(symbol)` – 단일 심볼의 모델을 학습하고 저장합니다.【F:f5_ml_pipeline/06_train.py†L47-L139】
+- `main()` – 학습용 파일을 순회하며 `train_and_eval()`을 호출합니다.【F:f5_ml_pipeline/06_train.py†L142-L155】
 
 ## 실행 방법
 ```bash
@@ -18,6 +22,7 @@ python f5_ml_pipeline/06_train.py
 모델과 로그 파일 위치는 스크립트 기준으로 결정되므로, 어디서 실행하더라도
 `f5_ml_pipeline/ml_data/05_split/`에서 학습 데이터를 읽고 `f5_ml_pipeline/ml_data/06_models/`에 결과를 저장합
 니다.
+로그 파일은 `f5_ml_pipeline/logs/ml_train.log`에 기록됩니다.
 
 모델 학습 파라미터는 `f5_ml_pipeline/config/train_config.yaml`에서 관리합니다.
 외부 패키지 없이 간단한 YAML 파서를 내장해 의존성을 최소화했으며


### PR DESCRIPTION
## Summary
- expand RiskManager documentation with clearer workflow and log paths
- clarify f5 ML pipeline scripts (`01_data_collect.py`, `05_split.py`, `06_train.py`)
- add code references for important functions

## Testing
- `pytest -q`