### PR TITLE
Improve documentation for ML flow

### DIFF
--- a/doc/01_select_universe.md
+++ b/doc/01_select_universe.md
@@ -1,68 +1,57 @@
-# 유니버스 선정 개편안
+# 유니버스 결정 절차
 
-이 문서는 새롭게 구성될 **F1 모듈**의 코인 필터링 과정을 정리한 초안입니다. 앞으로 웹
-대시보드와 연계해 모니터링 대상 코인과 머신러닝 학습용 코인을 쉽게 관리하려는 목적이
-있습니다.
+이 문서는 F1 모듈이 어떤 방식으로 매매 대상 코인 목록(유니버스)을
+결정하는지 단계별로 설명합니다. 초보 기획자가 읽어도 이해할 수 있도록
+관련 파일과 동작 흐름을 간단하게 정리했습니다.
 
-## 1. 모니터링 대상 코인 선택
+## 핵심 역할
 
-1. ML 파이프라인의 결과물인 `f5_ml_pipeline/ml_data/10_selected/selected_strategies.json`
-   파일에 `symbol` 목록이 존재하면 이를 우선 사용합니다.
-2. 사용자는 웹 화면에서 각 코인을 **허용** 또는 **미허용**으로 지정할 수 있습니다.
-   - 메뉴 예시: "매수대상 코인선정".
-3. 허용된 코인만 실제 모니터링 대상(유니버스)으로 채택됩니다.
+- **모니터링 대상**을 정해 F2/F3가 실시간으로 다룰 코인을 제한합니다.
+- **데이터 수집 대상**을 정해 F5 머신러닝 학습을 위한 데이터를 모읍니다.
 
-## 2. 데이터 수집용 코인 필터링
+주요 코드는 `f1_universe/universe_selector.py`에 있으며 주기적으로
+`config/current_universe.json`에 결과를 저장합니다.
 
-웹 메뉴 "데이터 수집 코인선정"에서 다음 조건을 입력받습니다.
+## 사용되는 파일
 
-```json
-{
-  "min_price": 700.0,
-  "max_price": 23000.0,
-  "volume_rank": 30,
-  "min_24h_trade_price": 1000000000.0
-}
-```
+| 파일 | 설명 |
+| ---- | ---- |
+| `config/coin_list_monitoring.json` | 실전 모니터링에 사용할 코인 목록. 빈 배열이면 다른 데이터로 대체됩니다. |
+| `f5_ml_pipeline/ml_data/10_selected/selected_strategies.json` | 백테스트에서 선별된 코인 목록 |
+| `config/universe.json` | 가격, 거래량 등 기본 필터 조건. |
+| `config/coin_list_data_collection.json` | 학습용 데이터를 수집할 코인 목록. |
+| `config/filter_coin_data_collection.json` | 데이터 수집 시 적용할 가격·거래량 조건. |
+> `coin_list_monitoring.json`이 비어 있으면 위 전략 목록을 우선 사용합니다.
+| `config/current_universe.json` | 마지막으로 선택된 유니버스가 기록되는 파일. |
 
-이 조건에 맞는 모든 코인에 대해 1분 주기로 데이터를 수집합니다.
+로그는 `logs/F1_signal_engine.log`와 `logs/F1-F2_loop.log`에 저장됩니다.
 
-## 3. 수집 데이터 종류
+## 주요 함수
 
-- **1분봉(OHLCV)**: 시장, UTC/KST 시각, 시가, 고가, 저가, 종가, 누적 거래대금 등
-- **호가(Orderbook)**: 매수/매도 호가 15단계와 잔량 정보
-- **체결(Trades)**: 체결 시각, 가격, 수량, 체결 ID 등
-- **시세(Ticker)**: 실시간 가격, 변동률, 24시간 거래량 등
+- `load_monitoring_coins()` – 모니터링 목록을 읽어 리스트로 반환합니다.
+- `load_selected_universe()` – ML 파이프라인에서 선별한 목록을 읽어옵니다.
+- `select_universe()` – 위 두 목록을 순서대로 확인한 뒤 없으면
+  `load_universe_from_file()` 결과를 사용합니다.
+- `update_universe()` – 선택된 유니버스를 메모리와 `current_universe.json`에 갱신합니다.
+- `schedule_universe_updates()` – 주기적으로 `update_universe()`를 호출하는 백그라운드 스레드를 시작합니다.
 
-## 4. 활용 목적
+## 동작 흐름
 
-1. **모니터링용 데이터**
-   - `selected_strategies.json`에서 선택된 코인에 한해 매수/매도 모니터링에 활용합니다.
-2. **머신러닝 학습 데이터**
-   - `03_feature_engineering.py`에서 기술적 지표 계산에 사용됩니다.
-   - `04_labeling.py`에서 매매 신호 라벨을 생성할 때 참조합니다.
+1. **전략 선별(F5 모듈)**
+   - `f5_ml_pipeline/10_select_best_strategies.py`가 백테스트 결과를 평가하여
+     좋은 심볼을 `config/coin_list_monitoring.json`에 저장합니다.
+2. **유니버스 로드**
+   - `signal_loop.py` 실행 시 `schedule_universe_updates()`가 동작하여
+     30분마다 `select_universe()`를 호출합니다.
+   - `select_universe()`는 `coin_list_monitoring.json` → `selected_strategies.json`
+     → `current_universe.json` 순으로 확인해 첫 번째로 발견된 리스트를 사용합니다.
+3. **파일 갱신**
+   - 결정된 유니버스는 `config/current_universe.json`에 기록되어
+     다른 모듈이 동일한 목록을 참조할 수 있게 합니다.
+4. **데이터 수집**
+   - 별도로 실행되는 `f5_ml_pipeline/01_data_collect.py`는
+     `coin_list_data_collection.json`과 `filter_coin_data_collection.json`을 읽어
+     학습용 데이터를 수집합니다.
 
-## 5. 설정 파일 구조
-
-- `config/coin_list_monitoring.json` – 웹에서 허용으로 지정한 모니터링 대상 코인 리스트
-- `config/coin_list_data_collection.json` – 데이터 수집에 사용할 코인 리스트
-- `config/filter_coin_data_collection.json` – 데이터 수집 조건 값
-- `f5_ml_pipeline/ml_data/10_selected/selected_strategies.json` – ML에서 추린 후보 목록
-
-### 예시 JSON 구조
-
-두 코인 리스트 파일은 아래와 같이 심볼 문자열 배열을 저장합니다.
-
-```json
-[
-    "KRW-BTC",
-    "KRW-ETH",
-    "KRW-XRP"
-]
-```
-
-## 추가
-
-- 데이터 수집 스케줄은 코인 수가 많아질수록 부하가 커지므로 1분 간격 작업이 겹치지 않게 스레드 풀이나 비동기 방식을 고려합니다.
-- 웹 대시보드는 단순 토글만 제공하고 실제 저장은 JSON 파일로 관리하면 버전 관리가 용이합니다.
-
+이 구조를 통해 모니터링 대상과 학습용 대상이 분리되며,
+웹 대시보드나 ML 파이프라인 결과에 따라 유니버스가 자동으로 업데이트됩니다.

--- a/doc/02_coin_buy_logic.md
+++ b/doc/02_coin_buy_logic.md
@@ -1,88 +1,61 @@
-# 코인 매수 모니터링 로직
+# 코인 매수 로직
 
-이 문서는 F2 모듈에서 매수 신호를 감지하고 F3 모듈에서 실제 매수 주문을 실행하는 과정을 설명합니다. 코드 흐름과 사용되는 주요 함수, 변수들을 초보 기획자도 이해하기 쉽게 정리했습니다.
+이 문서는 F2 모듈에서 매수 신호를 계산하고 F3 모듈이 실제 주문을
+어떻게 수행하는지 설명합니다. 초보 기획자를 위해 관련 파일과
+함수를 한눈에 볼 수 있게 정리했습니다.
 
 ## 관련 파일
-- `f2_signal/signal_engine.py` – 매수/매도 조건 계산 함수 `f2_signal` 정의
-- `f3_order/order_executor.py` – 신호를 받아 주문을 처리하는 `OrderExecutor` 클래스
-- `f3_order/smart_buy.py` – 시장가와 IOC 주문을 조합한 `smart_buy` 함수
-- `f3_order/position_manager.py` – 포지션 정보를 저장하고 갱신하는 `PositionManager`
 
-## 주요 함수와 변수
+| 경로 | 용도 |
+| --- | --- |
+| `f2_ml_buy_signal/f2_ml_buy_signal.py` | 경량 머신러닝으로 실시간 매수 신호를 판단합니다. |
+| `f2_ml_buy_signal/f2_data/` | 단계별 임시 Parquet 파일 저장 위치 |
+| `f2_signal/signal_engine.py` | `f2_signal()` 함수에서 1분 봉 데이터를 받아 ML 모델을 호출합니다. |
+| `f3_order/order_executor.py` | 매수 신호를 받아 주문을 실행하는 `OrderExecutor` 클래스가 있습니다. |
+| `f3_order/position_manager.py` | 포지션을 저장·관리하며 주문 결과를 기록합니다. |
+| `config/coin_list_monitoring.json` | 모니터링할 코인 목록. F5 단계에서 생성됩니다. |
+| `config/coin_realtime_buy_list.json` | 매수 대상이 발견되면 `{심볼: 0}` 형식으로 기록됩니다. |
+| `config/coin_realtime_sell_list.json` | 손절·익절·트레일링 스탑 설정을 저장합니다. |
+| `config/risk.json` | 매매 금액과 손절 비율 등 위험 관리 값 |
 
-### `f2_signal(df_1m, df_5m, symbol="", trades=None, calc_buy=True, calc_sell=True, strategy_codes=None)`
-`f2_signal`은 머신러닝 모델을 이용해 1분 봉 데이터에서 매수 신호를 계산합니다. 기존의 전략 공식은 사용하지 않으며 반환 값의 형식은 다음과 같습니다.
-```python
-{
-    "symbol": symbol,
-    "buy_signal": bool,    # 매수 가능 여부
-    "sell_signal": bool,   # 매도 가능 여부
-    "buy_triggers": [],
-    "sell_triggers": []
-}
-```
-매수 조건이 충족되면 `buy_signal`이 `True`가 됩니다.
-별도의 `f2_ml_buy_signal.run()` 함수가 `coin_list_monitoring.json`에 있는 종목을
-순회하면서 이 값을 확인하고, `config/coin_realtime_buy_list.json`에 매수 대상을
-`{심볼: 0}` 형식으로 추가합니다.
-동일 심볼이 이미 존재하면 값은 유지됩니다.
-아울러 손절/익절/트레일링 스탑 설정은 `coin_realtime_sell_list.json`에 함께 저장됩니다.
-【F:f2_ml_buy_signal/f2_ml_buy_signal.py†L221-L259】
-`run_if_monitoring_list_exists()`를 사용하면 모니터링 리스트 파일이 존재할 때만
-자동으로 이 루틴이 실행됩니다. 파일이 없으면 빈 리스트를 반환하고 아무 작업도 하지
-않습니다.
+로그는 `logs/f2_ml_buy_signal.log`, `logs/F2_signal_engine.log`,
+`logs/F3_order_executor.log` 등에 남습니다.
 
+## 주요 함수
+
+### `run_if_monitoring_list_exists()`
+`config/coin_list_monitoring.json` 파일이 존재할 때만 `run()`을 호출합니다.
+파일이 없으면 아무 작업도 하지 않습니다.
+
+### `run()`
+1. 모니터링 목록을 읽어 각 코인에 대해 `check_buy_signal()`을 수행합니다.
+2. 신호가 `True`이면 `coin_realtime_buy_list.json`과
+   `coin_realtime_sell_list.json`을 갱신합니다.
+3. 과정과 결과는 `logs/f2_ml_buy_signal.log`에 기록됩니다.
+
+### `f2_signal(df_1m, df_5m, symbol="", ...)`
+`signal_loop.py`에서 호출되어 실제 매매 루프를 돌 때 사용됩니다.
+`check_buy_signal_df()`를 이용해 1분 봉 데이터에서 바로 신호를 계산하며
+매수 가능 여부를 `buy_signal` 필드로 반환합니다.
 
 ### `OrderExecutor.entry(signal)`
-`OrderExecutor.entry`는 위 결과를 받아 실제 매수 주문을 수행합니다.
-RiskManager에서 특정 심볼이 차단되었는지 확인한 후 `smart_buy`를 호출하여 주문을
-시도합니다. 체결되면 `PositionManager.open_position`으로 포지션이 저장됩니다.
-【F:f3_order/order_executor.py†L48-L96】
-
-### `smart_buy(signal, config, dynamic_params, position_manager, parent_logger=None)`
-`smart_buy`는 스프레드가 넓을 경우 IOC 주문을 우선 시도하고 실패 시 시장가 주문으로
-넘어갑니다. 주문 수량은 `config["ENTRY_SIZE_INITIAL"]`을 사용해 계산하며 최소 수량은
-0.0001로 제한됩니다.【F:f3_order/smart_buy.py†L20-L53】
-
-### 주요 설정 값
-- `ENTRY_SIZE_INITIAL` – 첫 매수 시 투입하는 원화 금액
-- `MAX_RETRY` – IOC 주문 재시도 횟수 (기본 2회)
-- `SPREAD_TH` – 스프레드 임계값. 이보다 좁으면 바로 시장가 주문
-
-위 값들은 `config/setting_date/Latest_config.json` 또는 기타 설정 파일에서 관리됩니다.【F:config/setting_date/Latest_config.json†L1-L23】
-매수 신호 계산 과정과 결과는 `logs/f2_ml_buy_signal.log`에 기록됩니다.
-필수 패키지가 없으면 해당 오류 메시지도 이 파일에 남습니다.
-최근 업데이트로 실행 시작과 종료, 데이터 수집, 예측 확률 등 세부 정보가 모두 로그에
-표시되므로 문제 발생 시 원인을 쉽게 추적할 수 있습니다.
-로그 항목은 다음 예시와 비슷한 형태를 가집니다.
-
-```
-2024-01-01 00:00:00 [F2] [INFO] [RUN] starting buy signal scan
-2024-01-01 00:00:00 [F2] [INFO] [RUN] loaded coin_list_monitoring.json: ['KRW-ETH']
-2024-01-01 00:00:00 [F2] [INFO] [RUN] existing buy_list={}
-2024-01-01 00:00:00 [F2] [INFO] [ETH] buy_signal=1
-2024-01-01 00:00:00 [F2] [INFO] [ETH] added to buy list with 0
-2024-01-01 00:00:00 [F2] [INFO] [RUN] saved buy_list={'KRW-ETH': 0}
-2024-01-01 00:00:00 [F2] [INFO] [RUN] finished. 1 coins to buy
-```
-
-각 메시지는 `[RUN]` 단계, 개별 종목 처리 결과, 파일 저장 여부 등을 모두 남기므로
-어떤 과정을 거쳐 매수 대상이 결정됐는지 한눈에 확인할 수 있습니다.
-
-추가로 각 단계별 중간 데이터를 `f2_ml_buy_signal/f2_data` 폴더에 저장해 검증할 수
-있습니다.
-
-- `01_data` – 원시 OHLCV
-- `02_clean_data` – 정제된 데이터
-- `03_data` – 피처 엔지니어링 결과
-- `04_data` – 라벨링 결과
-- `05_data` – 학습/검증/테스트 분할
-- `06_data` – 학습된 모델
+매수 신호가 `True`일 때 호출되어 실거래를 시도합니다.
+수량 계산, 슬리피지 체크, 포지션 등록 등을 모두 처리하며
+실패 시 재시도나 오류 로그가 남습니다.
 
 ## 동작 흐름
-1. `signal_loop.py`의 `process_symbol`에서 각 심볼의 OHLCV 데이터를 받아 `f2_signal`을 호출합니다.
-2. 반환된 딕셔너리에서 `buy_signal`이 `True`이면 `OrderExecutor.entry`가 실행됩니다.
-3. `entry` 내부에서 동일 심볼의 기존 포지션을 확인하고, 없을 경우 `smart_buy`로 주문을 시도합니다.
-4. 주문이 체결되면 `PositionManager.open_position`을 통해 포지션 목록에 추가되고, 텔레그램 알림이 전송됩니다.
 
-이 과정을 통해 시스템은 지속적으로 코인을 모니터링하며 매수 조건이 충족될 때 자동으로 주문을 실행합니다.
+1. **전략 선별** – `f5_ml_pipeline/10_select_best_strategies.py`가
+   우수 전략을 추려 `coin_list_monitoring.json`을 갱신합니다.
+2. **모니터링** – `signal_loop.py`에서 주기적으로 `f2_signal`을 호출해
+   각 코인의 1분 봉 데이터를 분석합니다.
+3. **ML 신호 판단** – `run_if_monitoring_list_exists()`가 실행되면
+   별도의 경량 ML 모델이 최근 데이터를 학습한 뒤 바로 예측을 수행합니다.
+   확률이 0.5 이상이면 매수 대상으로 판단합니다.
+4. **주문 실행** – `OrderExecutor.entry()`가 `smart_buy()`를 호출해
+   시장가 혹은 IOC 주문을 보내고, 체결되면 `PositionManager`에
+   포지션이 저장됩니다.
+5. **로그 기록** – 모든 과정은 `logs` 폴더에 남아 나중에 분석할 수 있습니다.
+
+위 절차를 통해 시스템은 모니터링 목록에 있는 코인을 실시간으로 살펴보고
+매수 조건이 충족되면 자동으로 주문을 진행합니다.

--- a/doc/04_risk_logic.md
+++ b/doc/04_risk_logic.md
@@ -1,6 +1,7 @@
 # 리스크 관리 로직
 
-이 문서는 F4 모듈에서 계좌 손익과 시스템 상태를 감시하여 자동으로 매매를 제어하는 방법을 설명합니다. `RiskManager`는 모든 포지션을 통제하며 일시 중단(PAUSE)이나 전면 중단(HALT)을 결정합니다.
+이 문서는 F4 모듈이 계좌 손익과 시스템 상태를 감시해 자동으로 매매를 제어하는 과정을 설명합니다.
+`RiskManager`는 모든 포지션을 통제하며 필요에 따라 PAUSE나 HALT 상태를 결정합니다.
 
 ## 관련 파일
 - `f4_riskManager/risk_manager.py` – 리스크 FSM과 핵심 로직을 포함한 `RiskManager`
@@ -14,7 +15,8 @@
 현재 계좌 손익과 보유 코인 목록을 업데이트합니다. 여기서 전달된 정보는 다음 `check_risk` 호출 때 사용됩니다.【F:f4_riskManager/risk_manager.py†L60-L71】
 
 ### `RiskManager.check_risk()`
-1Hz 주기로 호출되어 손실 한도 초과 여부, MDD(최대 낙폭) 초과 여부, 동시 보유 코인 수 등을 점검합니다. 조건을 위반하면 `pause` 또는 `halt`가 실행됩니다.【F:f4_riskManager/risk_manager.py†L89-L118】
+1Hz 주기로 호출되어 손실 한도와 MDD 한도, 동시 보유 코인 수를 점검합니다.
+조건을 위반하면 `pause()` 또는 `halt()`가 실행됩니다. [f4_riskManager/risk_manager.py]
 
 ### `RiskManager.pause(minutes, reason="")`
 일정 시간 동안 신규 진입을 차단합니다. 기존 포지션은 모두 청산하며 상태가 `PAUSE`로 바뀝니다.【F:f4_riskManager/risk_manager.py†L120-L139】
@@ -24,7 +26,8 @@
 
 ### `RiskManager.hot_reload()`
 
-설정 파일(`Latest_config.json`)이 변경되었는지 감지하여 실시간으로 파라미터를 갱신합니다. 갱신 시 `OrderExecutor`의 거래 금액 등도 동기화됩니다.【F:f4_riskManager/risk_manager.py†L170-L183】
+설정 파일(`Latest_config.json`) 변경을 감지해 실시간으로 파라미터를 갱신합니다.
+갱신 시 `OrderExecutor`의 거래 금액 등도 함께 업데이트됩니다.
 ### `RiskManager.on_slippage(symbol)`
 슬리피지 한도를 초과한 주문이 발생하면 횟수를 기록하고 일정 횟수 이상이면 `disable_symbol`을 호출합니다.【F:f4_riskManager/risk_manager.py†L77-L87】
 
@@ -43,7 +46,7 @@
 - `MAX_SYMBOLS` – 동시에 보유 가능한 코인 수 제한
 - `SLIP_MAX` – 허용 슬리피지 한도(%)
 
-이 외에도 `ENTRY_SIZE_INITIAL`, `AVG_SIZE`, `PYR_SIZE` 등 주문 크기와 관련된 값도 동일한 파일에서 조정합니다.【F:config/setting_date/Latest_config.json†L1-L23】
+이 외에도 `ENTRY_SIZE_INITIAL`, `AVG_SIZE`, `PYR_SIZE` 등의 주문 크기 설정도 같은 파일에서 조정합니다.
 
 ## 동작 흐름
 1. `signal_loop.py`에서 매 루프마다 `RiskManager.update_account`로 실현 손익과 보유 코인을 전달합니다.

--- a/doc/f2_ml_buy_signal.md
+++ b/doc/f2_ml_buy_signal.md
@@ -1,0 +1,27 @@
+# F2 실시간 ML 매수 신호
+
+`f2_ml_buy_signal/f2_ml_buy_signal.py`는 머신러닝을 이용해 실시간 매수 가능성을 판단합니다.
+`config/coin_list_monitoring.json` 파일이 존재할 때만 동작하며 1분봉 데이터가 갱신되는 시점에 호출됩니다.
+## 주요 경로
+| 파일/폴더 | 설명 |
+| --- | --- |
+| `f2_ml_buy_signal/f2_ml_buy_signal.py` | 전체 로직을 담은 스크립트 |
+| `f2_ml_buy_signal/f2_data/` | 각 단계별 Parquet 파일 저장 위치 |
+| `config/coin_list_monitoring.json` | 모니터링할 코인 목록 |
+| `config/coin_realtime_buy_list.json` | 실시간 매수 후보 |
+| `config/coin_realtime_sell_list.json` | 매수 시 설정되는 손절/익절 값 |
+| `config/risk.json` | 기본 SL/TP 비율 등 위험 관리 파라미터 |
+| `logs/f2_ml_buy_signal.log` | 실행 로그 |
+
+## 동작 순서
+1. `run_if_monitoring_list_exists()`가 `coin_list_monitoring.json` 파일 존재 여부를 확인합니다.
+2. 파일이 있으면 `run()`이 실행되어 리스트의 각 심볼에 대해 다음 과정을 거칩니다.
+   1. **데이터 수집** – `fetch_ohlcv()`가 최근 60개 1분봉을 다운로드합니다. 실패 시 0.2초 간격으로 세 번 재시도합니다.
+   2. **정제 및 지표 계산** – `_clean_df()`와 `_add_features()`가 데이터를 정리하고 EMA, RSI 등 기본 지표를 생성합니다.
+   3. **라벨 생성** – `_label()`이 미래 5분 후 가격을 기준으로 라벨을 부여합니다.
+   4. **학습/예측** – `_train_predict()`가 데이터를 학습한 뒤 마지막 행에 대해 로지스틱 회귀 예측을 수행하여 확률이 0.5 이상이면 매수 대상으로 판단합니다.
+   5. **리스트 갱신** – 매수 신호가 감지되면 `coin_realtime_buy_list.json`과 `coin_realtime_sell_list.json`에 해당 심볼이 기록됩니다.
+      위험 파라미터는 `risk.json`에서 읽어옵니다.
+3. 모든 과정은 `logs/f2_ml_buy_signal.log`에 단계별로 남아 이후 분석 시 활용됩니다.
+
+이렇게 F2 모듈은 가벼운 로지스틱 회귀 모델을 즉석 학습하여 각 1분봉 마감 시점에 매수 여부를 판단합니다. ML 파이프라인에서 선별된 모니터링 대상만 처리하므로 빠르게 동작하며 실시간 트레이딩에 적합합니다.

--- a/doc/f5ml_05_split.md
+++ b/doc/f5ml_05_split.md
@@ -1,7 +1,7 @@
 # F5ML_05_split.py 사용법
 
 `f5_ml_pipeline/ml_data/04_label/` 폴더의 라벨 데이터를 읽어 시간순으로 학습, 검증, 테스트 세트로 분할합니다.
-결과는 `f5_ml_pipeline/ml_data/05_split/`에 `{symbol}_train.parquet`, `{symbol}_valid.parquet`, `{symbol}_test.parquet` 형식으로 저장됩니다.
+결과는 `f5_ml_pipeline/ml_data/05_split/` 폴더에 저장되며 파일 이름은 `{symbol}_train.parquet` 등입니다.
 
 기본 분할 비율은 학습 70%, 검증 20%, 테스트 10%이며, 필요한 경우 코드 상에서 비율을 변경할 수 있습니다.
 


### PR DESCRIPTION
## Summary
- clarify how to choose universe and note monitoring list priority
- document F2 ML buy signal workflow
- refine buy, sell and risk management docs
- trim long lines in F5 split guide

## Testing
- `pytest -q`
