### PR TITLE
Remove unused trailing stop lists

### DIFF
--- a/doc/f5ml_labeling.md
+++ b/doc/f5ml_labeling.md
@@ -12,8 +12,6 @@
 
 - `THRESH_LIST = [0.005, 0.006, 0.007]`
 - `LOSS_LIST = [0.005, 0.006, 0.007]`
-- `TRAIL_START_LIST = [None, 0.004]`
-- `TRAIL_DOWN_LIST = [None, 0.002]`
 
 트레일링 스탑을 비활성화하려면 `trail_start_pct` 또는 `trail_down_pct` 값을
 `None`으로 설정합니다. 이 경우 라벨링과 백테스트는 단순 TP/SL 규칙만 사용합니다.

--- a/f5_ml_pipeline/04_labeling.py
+++ b/f5_ml_pipeline/04_labeling.py
@@ -19,8 +19,6 @@ LOG_PATH = PIPELINE_ROOT / "logs" / "ml_label.log"
 
 THRESH_LIST      = [0.005, 0.006, 0.007]    # 익절(%)
 LOSS_LIST        = [0.005, 0.006, 0.007]    # 손절(%)
-TRAIL_START_LIST = [None, 0.004]           # 트레일링 시작(%)
-TRAIL_DOWN_LIST  = [None, 0.002]           # 트레일링 하락(%)
 HORIZON          = 5                       # 구간 고정
 
 def setup_logger() -> None:
@@ -142,10 +140,16 @@ def to_py_types(obj):
 def optimize_labeling_trailing(df: pd.DataFrame, symbol: str) -> dict:
     """트레일링 포함 파라미터 그리드 전체 실험, 최적 조합 자동 선정."""
     results = []
-    for thresh, loss, trail_start, trail_down in product(
-        THRESH_LIST, LOSS_LIST, TRAIL_START_LIST, TRAIL_DOWN_LIST
-    ):
-        df_labeled = make_labels_trailing(df, HORIZON, thresh, loss, trail_start, trail_down)
+    for thresh, loss in product(THRESH_LIST, LOSS_LIST):
+        trail_start, trail_down = None, None
+        df_labeled = make_labels_trailing(
+            df,
+            HORIZON,
+            thresh,
+            loss,
+            trail_start,
+            trail_down,
+        )
         n = len(df_labeled)
         n1 = (df_labeled["label"] == 1).sum()
         n2 = (df_labeled["label"] == 2).sum()


### PR DESCRIPTION
## Summary
- drop `TRAIL_START_LIST` and `TRAIL_DOWN_LIST`
- search parameters now only use threshold and loss
- update documentation accordingly

## Testing
- `pytest -q`