### PR TITLE
Add docs for f9_ml_pipeline_backup

### DIFF
--- a/doc/f5ml_01_data_collect.md
+++ b/doc/f5ml_01_data_collect.md
@@ -1,13 +1,13 @@
 # F5ML_01_data_collect.py 사용법
 
 `f1_f5_data_collection_list.json`에 명시된 코인들을 매 분마다 호출하여
-OHLCV, 호가, 체결, 시세 데이터를 수집합니다.
-수집된 데이터는 `f5_ml_pipeline/ml_data/01_raw/<데이터종류>/` 폴더에
+**OHLCV** 데이터만 수집합니다.
+수집된 파일은 `f5_ml_pipeline/ml_data/01_raw/` 폴더에
 Parquet 형식으로 저장됩니다.
 
 ## 주요 기능
 - `load_coin_list()` 함수가 모니터링 목록을 읽어 리스트를 반환합니다.
-- 매 분 정각 이후 5초에 `collect_once()`가 한 번씩 호출되어 OHLCV, 호가, 체결, 시세를 다운로드합니다.
+- 매 분 정각 이후 5초에 `collect_once()`가 한 번씩 호출되어 OHLCV를 다운로드합니다.
 - `save_data()`가 기존 파일을 불러와 중복을 제거한 뒤 누적 저장합니다.
 - 모든 과정은 `logs/data_collect.log`에 기록되어 누락 여부를 확인할 수 있습니다.
 
@@ -16,9 +16,9 @@ Parquet 형식으로 저장됩니다.
 
 ### 코드 구조
 - `load_coin_list()` – 수집 대상 코인을 불러옵니다.【F:f5_ml_pipeline/01_data_collect.py†L57-L68】
-- `collect_once()` – 한 번 실행으로 OHLCV, 호가 등 네 종류의 데이터를 모두 수집합니다.【F:f5_ml_pipeline/01_data_collect.py†L152-L177】
-- `next_minute()` – 다음 분 시작 시각을 계산해 루프 타이밍을 맞춥니다.【F:f5_ml_pipeline/01_data_collect.py†L180-L183】
-- `main()` – 무한 루프를 돌며 `collect_once()`를 호출합니다.【F:f5_ml_pipeline/01_data_collect.py†L186-L213】
+- `collect_once()` – 지정된 코인의 OHLCV를 저장합니다.【F:f5_ml_pipeline/01_data_collect.py†L138-L147】
+- `next_minute()` – 다음 분 시작 시각을 계산해 루프 타이밍을 맞춥니다.【F:f5_ml_pipeline/01_data_collect.py†L151-L154】
+- `main()` – 무한 루프를 돌며 `collect_once()`를 호출합니다.【F:f5_ml_pipeline/01_data_collect.py†L157-L184】
 
 다음과 같이 실행할 수 있습니다.
 ```bash

--- a/doc/f5ml_data_cleaning.md
+++ b/doc/f5ml_data_cleaning.md
@@ -1,16 +1,12 @@
 # F5ML_02_data_cleaning.py 사용법
 
-`f5_ml_pipeline/ml_data/01_raw/` 폴더(및 하위 디렉터리)에 있는 업비트 원본 데이터를
+`f5_ml_pipeline/ml_data/01_raw/` 폴더에 저장된 OHLCV 원본 데이터를
 머신러닝에 적합한 형식으로 정제하여 `f5_ml_pipeline/ml_data/02_clean/` 하위에 저장합니다.
-`ohlcv`, `ticker`, `trades`, `orderbook` 등 타입별 폴더 구조를 인식하며,
-같은 심볼의 여러 파일이 있을 경우 자동 병합 후 하나의 결과 파일을 생성합니다.
+데이터는 OHLCV만 존재하므로 여러 파일이 있을 경우 자동 병합 후 하나의 결과 파일을 생성합니다.
 
 ## 주요 기능
 - 폴더와 하위 폴더의 모든 CSV/XLSX/Parquet 파일을 자동 탐색합니다.
 - 동일 심볼의 여러 파일이 존재하면 하나로 병합해 저장합니다.
-- `ohlcv`를 기준으로 `ticker`와 `orderbook`은 가장 가까운 시각의 데이터를
-  선택해 병합합니다.
-- `trades` 데이터는 1분 단위로 가격 평균과 거래량 합계를 집계한 후 병합합니다.
 - 파일명에서 심볼을 추출해 `{symbol}_clean.parquet` 형식으로 저장합니다.
 - 업비트 원본 컬럼(`opening_price`, `high_price`, `low_price`, `trade_price`,
   `candle_acc_trade_volume`, `candle_date_time_utc`)을 각각 `open`, `high`, `low`,
@@ -25,7 +21,7 @@
 python f5_ml_pipeline/02_data_cleaning.py
 ```
 
-실행 후 `f5_ml_pipeline/ml_data/02_clean/<type>/` 폴더에 `{symbol}_clean.parquet` 파일이 생성됩니다.
+실행 후 `f5_ml_pipeline/ml_data/02_clean/` 폴더에 `{symbol}_clean.parquet` 파일이 생성됩니다.
 데이터가 크게 줄어든 경우 경고가 표시됩니다.
 모든 스크립트는 자신의 폴더를 기준으로 절대 경로를 계산하므로 어느 위치에서 실행해도 `f5_ml_pipeline/ml_data/` 아래에 결과가 저장됩니다.
 

--- a/doc/f9ml_pipeline_backup.md
+++ b/doc/f9ml_pipeline_backup.md
@@ -1,0 +1,8 @@
+# F9ML Pipeline Backup
+
+The `f9_ml_pipeline_backup` directory is a frozen copy of
+`f5_ml_pipeline`. It preserves all original scripts and data for
+reference. **Do not modify or run files in this directory.**
+
+Updates to the machine learning pipeline should be made only in
+`f5_ml_pipeline`.

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -26,6 +26,8 @@ This repository implements a four stage trading system built around the Upbit ex
 - **F4 Risk Manager** – enforces drawdown limits and other protections. It can pause
   or halt trading when risk thresholds are breached.
 - **F5ML 머신러닝 파이프라인** – 매매 의사결정에 사용되는 모델을 학습하고 평가합니다. 스크립트는 `f5_ml_pipeline/`에 있습니다.
+- **F9ML Pipeline Backup** – `f9_ml_pipeline_backup/`은 기존 `f5_ml_pipeline`의 전체 사본으로,
+  참고 용도로만 남겨둔 폴더입니다. 이 디렉터리의 파일은 수정하거나 실행하지 않습니다.
 
 모든 파이프라인 스크립트는 자신의 위치를 기준으로 절대 경로를 계산하므로 실행 디렉터리에 상관없이 `f5_ml_pipeline/ml_data/`에 데이터를 저장합니다.
 A lightweight Flask application in `app.py` exposes REST API endpoints for monitoring


### PR DESCRIPTION
## Summary
- document the new `f9_ml_pipeline_backup` folder
- mention the backup folder in the project overview
- limit realtime collector to OHLCV and save directly under `ml_data/01_raw`
- adjust data cleaning scripts for the new raw data layout

## Testing
- `pytest -q`
