### PR TITLE
Update ML buy signal flow

### DIFF
--- a/doc/02_coin_buy_logic.md
+++ b/doc/02_coin_buy_logic.md
@@ -17,7 +17,7 @@
 | `config/f5_f1_monitoring_list.json` | 모니터링할 코인 목록(`symbol`, `thresh_pct`, `loss_pct`). F5 단계에서 생성됩니다. |
 | `config/f2_f2_realtime_buy_list.json` | 매수 조건을 만족한 코인의 목록을 저장합니다. |
 | `config/f2_f2_realtime_sell_list.json` | (구 버전 호환용) 현재는 사용하지 않습니다. |
-| `config/f4_f2_risk_settings.json` | 매매 금액과 손절 비율 등 위험 관리 값. |
+| `config/f4_f2_risk_settings.json` | 현재 F2에서는 사용하지 않으며, 기본 위험 관리 값을 보관하는 참고용 파일입니다. |
 
 로그는 `logs/f2_ml_buy_signal.log`, `logs/F2_signal_engine.log`,
 `logs/F3_order_executor.log` 등에 남습니다.

--- a/doc/config.md
+++ b/doc/config.md
@@ -32,8 +32,8 @@ conditions. Each entry contains `symbol`, `buy_signal`, `rsi_sel`, `trend_sel`,
 Stores stop-loss and take-profit settings for each symbol detected by **F2**.
 
 ## f4_f2_risk_settings.json
-Simplified risk parameters (stop percentages, trailing stop etc.) referenced by **F2**
-when generating the real‑time sell list.
+Legacy risk parameters (stop percentages, trailing stop etc.). F2는 이제 `f5_f1_monitoring_list.json`에서
+`thresh_pct`와 `loss_pct` 값을 읽어 오므로 이 파일은 참고용으로만 유지됩니다.
 
 ## f3_f3_order_config.json
 Order execution defaults such as retry counts and quantity settings. Used only by **F3**.

--- a/doc/f2_ml_buy_signal.md
+++ b/doc/f2_ml_buy_signal.md
@@ -27,6 +27,8 @@ OHLCV 수집, 클리닝, 피처 생성, 라벨링, 학습, 예측을 모두 실�
    ]
    ```
 
+   실행 결과가 없더라도 파일은 매 실행마다 덮어쓰기 때문에,
+   신호가 없으면 빈 배열이 저장됩니다.
 3. 결과와 과정을 모두 `logs/f2_ml_buy_signal.log`에 기록합니다.
 
 ### `check_buy_signal(symbol)`
@@ -38,7 +40,8 @@ OHLCV 수집, 클리닝, 피처 생성, 라벨링, 학습, 예측을 모두 실�
 
 1. `signal_loop.py` 혹은 상위 스케줄러가 1분봉 종료 시 `run_if_monitoring_list_exists()`를 호출합니다.
 2. 스크립트는 `f5_f1_monitoring_list.json`이 존재할 때만 각 코인의 매수 신호를 판별합니다.
-3. 매수 신호가 `True`로 판단되면 해당 코인이 실시간 매수 리스트에 추가되고, 매도 기준은 `f4_f2_risk_settings.json`에서 가져와 `f2_f2_realtime_sell_list.json`에 함께 기록됩니다.
+3. 매수 신호가 `True`로 판단되면 해당 코인이 실시간 매수 리스트에 추가됩니다. 이때 `thresh_pct`와 `loss_pct` 값은
+   `f5_f1_monitoring_list.json`에서 불러온 값을 그대로 기록합니다.
 4. 모든 로그와 저장 위치는 `logs/f2_ml_buy_signal.log` 파일에서 확인할 수 있습니다.
 
 `f2_ml_buy_signal.py`를 통해 실시간으로 간단한 모델 학습과 예측을 반복하므로, 별도의 대용량 데이터 없이도 빠르게 매수 후보를 판단할 수 있습니다.

--- a/f2_ml_buy_signal/f2_ml_buy_signal.py
+++ b/f2_ml_buy_signal/f2_ml_buy_signal.py
@@ -332,11 +332,11 @@ def run() -> List[str]:
                 "loss_pct": loss,
             })
 
+    _save_json(buy_list_path, updated)
     if updated:
-        _save_json(buy_list_path, updated)
         logging.info("[RUN] saved buy_list=%s", updated)
     else:
-        logging.info("[RUN] no buy candidates")
+        logging.info("[RUN] cleared buy_list")
     logging.info("[RUN] finished. %d coins to buy", len(results))
     return results
 


### PR DESCRIPTION
## Summary
- overwrite realtime buy list every run so stale entries are cleared
- document that `f2_f2_realtime_buy_list.json` is overwritten each cycle
- clarify that F2 uses `f5_f1_monitoring_list.json` for threshold and loss values

## Testing
- `pytest -q`
