### PR TITLE
Update real-time buy/sell docs

### DIFF
--- a/doc/02_coin_buy_logic.md
+++ b/doc/02_coin_buy_logic.md
@@ -16,7 +16,7 @@
 | `f3_order/position_manager.py` | 포지션을 저장·관리하며 주문 결과를 기록합니다. |
 | `config/f5_f1_monitoring_list.json` | 모니터링할 코인 목록(`symbol`, `thresh_pct`, `loss_pct`). F5 단계에서 생성됩니다. |
 | `config/f2_f2_realtime_buy_list.json` | 매수 조건을 만족한 코인의 목록을 저장합니다. |
-| `config/f2_f2_realtime_sell_list.json` | (구 버전 호환용) 현재는 사용하지 않습니다. |
+| `config/f2_f2_realtime_sell_list.json` | 매수한 코인의 `thresh_pct`, `loss_pct` 값을 저장해 매도 주문에 활용합니다. |
 | `config/f4_f2_risk_settings.json` | 현재 F2에서는 사용하지 않으며, 기본 위험 관리 값을 보관하는 참고용 파일입니다. |
 
 로그는 `logs/f2_ml_buy_signal.log`, `logs/F2_signal_engine.log`,
@@ -30,8 +30,10 @@
 
 ### `run()`
 1. 모니터링 목록을 읽어 각 코인에 대해 `check_buy_signal()`을 수행합니다.
-2. 조건을 만족한 코인은 `[symbol, buy_signal, rsi_sel, trend_sel]` 정보를
-   포함하여 `f2_f2_realtime_buy_list.json`에 저장됩니다.
+2. 조건을 만족한 코인은 `[symbol, buy_signal, rsi_sel, trend_sel, buy_count]`
+   정보를 `f2_f2_realtime_buy_list.json`에 저장하고,
+   동시에 해당 코인의 `thresh_pct`, `loss_pct` 값을
+   `f2_f2_realtime_sell_list.json`에 기록합니다.
 3. 과정과 결과는 `logs/f2_ml_buy_signal.log`에 기록됩니다.
 
 ### `f2_signal(df_1m, df_5m, symbol="", ...)`

--- a/doc/config.md
+++ b/doc/config.md
@@ -22,10 +22,12 @@ and continuously updated by the **F3** order executor.
 ## f2_f2_realtime_buy_list.json
 List of dictionaries produced by **F2** when a coin meets the ML and indicator
 conditions. Each entry contains `symbol`, `buy_signal`, `rsi_sel`, `trend_sel`,
-`thresh_pct` and `loss_pct`.
+and `buy_count`.
 
 ## f2_f2_realtime_sell_list.json
-Stores stop-loss and take-profit settings for each symbol detected by **F2**.
+Stores `thresh_pct` and `loss_pct` for each symbol detected by **F2**. These
+values come from `f5_f1_monitoring_list.json` and are used when placing
+sell orders.
 
 ## f4_f2_risk_settings.json
 Legacy risk parameters (stop percentages, trailing stop etc.). F2는 이제 `f5_f1_monitoring_list.json`에서

--- a/doc/f2_ml_buy_signal.md
+++ b/doc/f2_ml_buy_signal.md
@@ -23,7 +23,7 @@
    ```json
    [
        {"symbol": "KRW-BTC", "buy_signal": 1, "rsi_sel": 1, "trend_sel": 1,
-        "thresh_pct": 0.003, "loss_pct": 0.003}
+        "buy_count": 0}
    ]
    ```
 
@@ -40,8 +40,8 @@
 
 1. `signal_loop.py` 혹은 상위 스케줄러가 1분봉 종료 시 `run_if_monitoring_list_exists()`를 호출합니다.
 2. 스크립트는 `f5_f1_monitoring_list.json`이 존재할 때만 각 코인의 매수 신호를 판별합니다.
-3. 매수 신호가 `True`로 판단되면 해당 코인이 실시간 매수 리스트에 추가됩니다. 이때 `thresh_pct`와 `loss_pct` 값은
-   `f5_f1_monitoring_list.json`에서 불러온 값을 그대로 기록합니다.
+3. 매수 신호가 `True`로 판단되면 해당 코인이 실시간 매수 리스트와 매도 설정 리스트에 추가됩니다. `thresh_pct`와 `loss_pct` 값은
+   `f5_f1_monitoring_list.json`에서 불러온 뒤 `f2_f2_realtime_sell_list.json`에 저장됩니다.
 4. 모든 로그와 저장 위치는 `logs/f2_ml_buy_signal.log` 파일에서 확인할 수 있습니다.
 
 `02_ml_buy_signal.py`는 학습된 모델을 활용해 최신 데이터를 즉시 예측하므로, 별도의 대용량 데이터 없이도 빠르게 매수 후보를 판별할 수 있습니다.

--- a/f2_ml_buy_signal/02_ml_buy_signal.py
+++ b/f2_ml_buy_signal/02_ml_buy_signal.py
@@ -349,6 +349,12 @@ def run() -> List[str]:
         buy_list = []
     logging.info("[RUN] existing buy_list=%s", buy_list)
 
+    sell_list_path = CONFIG_DIR / "f2_f2_realtime_sell_list.json"
+    sell_list = _load_json(sell_list_path)
+    if not isinstance(sell_list, dict):
+        sell_list = {}
+    logging.info("[RUN] existing sell_list=%s", sell_list)
+
     results = []
     updated: List[dict] = []
     for item in data if isinstance(data, list) else []:
@@ -371,11 +377,16 @@ def run() -> List[str]:
                 "buy_signal": 1,
                 "rsi_sel": int(rsi_flag),
                 "trend_sel": int(trend_flag),
-                "thresh_pct": thresh,
-                "loss_pct": loss,
+                "buy_count": 0,
             })
+            if thresh is not None and loss is not None:
+                sell_list[sym] = {
+                    "thresh_pct": thresh,
+                    "loss_pct": loss,
+                }
 
     _save_json(buy_list_path, updated)
+    _save_json(sell_list_path, sell_list)
     if updated:
         logging.info("[RUN] saved buy_list=%s", updated)
     else:

--- a/tests/test_ml_buy_list.py
+++ b/tests/test_ml_buy_list.py
@@ -24,6 +24,7 @@ def test_run_updates_buy_and_sell_lists(tmp_path, monkeypatch):
         ])
     )
     (cfg / "f2_f2_realtime_buy_list.json").write_text("[]")
+    (cfg / "f2_f2_realtime_sell_list.json").write_text("{}")
 
     # Stub optional dependencies before importing module
     pandas_stub = types.ModuleType("pandas")
@@ -53,8 +54,10 @@ def test_run_updates_buy_and_sell_lists(tmp_path, monkeypatch):
 
     result = ml.run()
     buy = json.loads((cfg / "f2_f2_realtime_buy_list.json").read_text())
+    sell = json.loads((cfg / "f2_f2_realtime_sell_list.json").read_text())
 
-    assert any(b["symbol"] == "KRW-BBB" for b in buy)
+    assert any(b["symbol"] == "KRW-BBB" and b.get("buy_count") == 0 for b in buy)
+    assert "KRW-AAA" in sell and sell["KRW-AAA"] == {"thresh_pct": 0.01, "loss_pct": 0.02}
     assert result == ["KRW-AAA", "KRW-BBB"]
 
 


### PR DESCRIPTION
## Summary
- document that both buy and sell lists are refreshed
- mention `buy_count`, `thresh_pct` and `loss_pct` in the buy logic doc

## Testing
- `pytest -q`