### PR TITLE
Clean up sell list entries

### DIFF
--- a/doc/02_coin_buy_logic.md
+++ b/doc/02_coin_buy_logic.md
@@ -32,8 +32,9 @@
 1. 모니터링 목록을 읽어 각 코인에 대해 `check_buy_signal()`을 수행합니다.
 2. 조건을 만족한 코인은 `[symbol, buy_signal, rsi_sel, trend_sel, buy_count]`
    정보를 `f2_f2_realtime_buy_list.json`에 저장하고,
-   동시에 해당 코인의 `thresh_pct`, `loss_pct` 값을
-   `f2_f2_realtime_sell_list.json`에 기록합니다.
+  동시에 해당 코인의 `thresh_pct`, `loss_pct` 값을
+  `f2_f2_realtime_sell_list.json`에 기록합니다. 이 과정에서 기존 항목에 남아 있던
+  `SL_PCT` 등의 필드는 자동으로 제거되며, 값이 남지 않는 항목은 삭제됩니다.
 3. 과정과 결과는 `logs/f2_ml_buy_signal.log`에 기록됩니다.
 
 ### `f2_signal(df_1m, df_5m, symbol="", ...)`

--- a/doc/f2_ml_buy_signal.md
+++ b/doc/f2_ml_buy_signal.md
@@ -42,7 +42,8 @@
 1. `signal_loop.py` 혹은 상위 스케줄러가 1분봉 종료 시 `run_if_monitoring_list_exists()`를 호출합니다.
 2. 스크립트는 `f5_f1_monitoring_list.json`이 존재할 때만 각 코인의 매수 신호를 판별합니다.
 3. 매수 신호가 `True`로 판단되면 해당 코인이 실시간 매수 리스트와 매도 설정 리스트에 추가됩니다. `thresh_pct`와 `loss_pct` 값은
-   `f5_f1_monitoring_list.json`에서 불러온 뒤 `f2_f2_realtime_sell_list.json`에 저장됩니다.
+   `f5_f1_monitoring_list.json`에서 불러온 뒤 `f2_f2_realtime_sell_list.json`에 저장됩니다. 이때 기존 항목에 남아 있던
+   `SL_PCT`나 `TP_PCT` 같은 위험 관련 필드는 자동으로 제거되며, 값이 남지 않는 항목은 목록에서 사라집니다.
 4. 모든 로그와 저장 위치는 `logs/f2_ml_buy_signal.log` 파일에서 확인할 수 있습니다.
 
 `02_ml_buy_signal.py`는 학습된 모델을 활용해 최신 데이터를 즉시 예측하므로, 별도의 대용량 데이터 없이도 빠르게 매수 후보를 판별할 수 있습니다.

--- a/f2_ml_buy_signal/02_ml_buy_signal.py
+++ b/f2_ml_buy_signal/02_ml_buy_signal.py
@@ -353,6 +353,20 @@ def run() -> List[str]:
     sell_list = _load_json(sell_list_path)
     if not isinstance(sell_list, dict):
         sell_list = {}
+    else:
+        for sym, info in list(sell_list.items()):
+            if not isinstance(info, dict):
+                del sell_list[sym]
+                continue
+            cleaned = {
+                k: info[k]
+                for k in ("thresh_pct", "loss_pct")
+                if k in info
+            }
+            if cleaned:
+                sell_list[sym] = cleaned
+            else:
+                del sell_list[sym]
     logging.info("[RUN] existing sell_list=%s", sell_list)
 
     results = []

--- a/tests/test_ml_buy_list.py
+++ b/tests/test_ml_buy_list.py
@@ -61,6 +61,114 @@ def test_run_updates_buy_and_sell_lists(tmp_path, monkeypatch):
     assert result == ["KRW-AAA", "KRW-BBB"]
 
 
+def test_existing_risk_fields_removed(tmp_path, monkeypatch):
+    cfg = tmp_path
+    (cfg / "f5_f1_monitoring_list.json").write_text(
+        json.dumps([
+            {"symbol": "KRW-LSK", "thresh_pct": 0.005, "loss_pct": 0.003},
+        ])
+    )
+    (cfg / "f2_f2_realtime_buy_list.json").write_text("[]")
+    (cfg / "f2_f2_realtime_sell_list.json").write_text(
+        json.dumps(
+            {
+                "KRW-LSK": {
+                    "SL_PCT": 1.0,
+                    "TP_PCT": 1.2,
+                    "TRAILING_STOP_ENABLED": True,
+                    "TRAIL_START_PCT": 0.7,
+                    "TRAIL_STEP_PCT": 1.0,
+                }
+            }
+        )
+    )
+
+    pandas_stub = types.ModuleType("pandas")
+    pandas_stub.Series = object
+    pandas_stub.DataFrame = object
+    sklearn_stub = types.ModuleType("sklearn")
+    linear_stub = types.ModuleType("sklearn.linear_model")
+    linear_stub.LogisticRegression = object
+    joblib_stub = types.ModuleType("joblib")
+    joblib_stub.dump = lambda *a, **k: None
+    joblib_stub.load = lambda *a, **k: None
+    numpy_stub = types.ModuleType("numpy")
+    sys.modules.update(
+        {
+            "pandas": pandas_stub,
+            "sklearn": sklearn_stub,
+            "sklearn.linear_model": linear_stub,
+            "joblib": joblib_stub,
+            "numpy": numpy_stub,
+            "pyupbit": types.ModuleType("pyupbit"),
+        }
+    )
+
+    from importlib import import_module
+
+    ml = import_module("f2_ml_buy_signal.02_ml_buy_signal")
+
+    monkeypatch.setattr(ml, "CONFIG_DIR", Path(cfg))
+    monkeypatch.setattr(ml, "check_buy_signal", Dummy((True, True, True)))
+
+    ml.run()
+
+    sell = json.loads((cfg / "f2_f2_realtime_sell_list.json").read_text())
+    assert sell == {"KRW-LSK": {"thresh_pct": 0.005, "loss_pct": 0.003}}
+
+
+def test_old_sell_entry_dropped(tmp_path, monkeypatch):
+    cfg = tmp_path
+    (cfg / "f5_f1_monitoring_list.json").write_text(
+        json.dumps([
+            {"symbol": "KRW-AAA", "thresh_pct": 0.01, "loss_pct": 0.02},
+        ])
+    )
+    (cfg / "f2_f2_realtime_buy_list.json").write_text("[]")
+    (cfg / "f2_f2_realtime_sell_list.json").write_text(
+        json.dumps(
+            {
+                "KRW-LSK": {
+                    "SL_PCT": 1.0,
+                }
+            }
+        )
+    )
+
+    pandas_stub = types.ModuleType("pandas")
+    pandas_stub.Series = object
+    pandas_stub.DataFrame = object
+    sklearn_stub = types.ModuleType("sklearn")
+    linear_stub = types.ModuleType("sklearn.linear_model")
+    linear_stub.LogisticRegression = object
+    joblib_stub = types.ModuleType("joblib")
+    joblib_stub.dump = lambda *a, **k: None
+    joblib_stub.load = lambda *a, **k: None
+    numpy_stub = types.ModuleType("numpy")
+    sys.modules.update(
+        {
+            "pandas": pandas_stub,
+            "sklearn": sklearn_stub,
+            "sklearn.linear_model": linear_stub,
+            "joblib": joblib_stub,
+            "numpy": numpy_stub,
+            "pyupbit": types.ModuleType("pyupbit"),
+        }
+    )
+
+    from importlib import import_module
+
+    ml = import_module("f2_ml_buy_signal.02_ml_buy_signal")
+
+    monkeypatch.setattr(ml, "CONFIG_DIR", Path(cfg))
+    monkeypatch.setattr(ml, "check_buy_signal", Dummy((True, True, True)))
+
+    ml.run()
+
+    sell = json.loads((cfg / "f2_f2_realtime_sell_list.json").read_text())
+    assert sell == {"KRW-AAA": {"thresh_pct": 0.01, "loss_pct": 0.02}}
+
+
 def test_run_records_non_signals(tmp_path, monkeypatch):
     cfg = tmp_path
     (cfg / "f5_f1_monitoring_list.json").write_text(


### PR DESCRIPTION
## Summary
- remove outdated risk fields and drop empty entries in `f2_f2_realtime_sell_list.json`
- document that empty sell-list entries are deleted
- test removal of unused sell list entries

## Testing
- `pytest tests/test_ml_buy_list.py::test_old_sell_entry_dropped -q`
- `pytest -q`