### PR TITLE
Add buy list executor

### DIFF
--- a/doc/02_coin_buy_logic.md
+++ b/doc/02_coin_buy_logic.md
@@ -61,3 +61,17 @@
 
 위 절차를 통해 시스템은 모니터링 목록에 있는 코인을 실시간으로 살펴보고
 매수 조건이 충족되면 자동으로 주문을 진행합니다.
+
+## 실시간 매수 리스트 활용
+
+`f2_ml_buy_signal.run()`이 작성한 `config/f2_f2_realtime_buy_list.json`을 그대로
+사용해 주문을 실행하려면 `f2_signal.buy_list_executor.execute_buy_list()` 함수를
+호출하면 됩니다. 이 함수는 리스트에서 `"buy_signal": 1`인 항목을 골라 현재
+가격을 조회한 뒤 `OrderExecutor.entry()`로 전달합니다.
+
+```python
+from f2_signal.buy_list_executor import execute_buy_list
+execute_buy_list()
+```
+
+모듈을 스크립트로 실행하면 자동으로 위 과정을 수행합니다.

--- a/tests/test_buy_list_executor.py
+++ b/tests/test_buy_list_executor.py
@@ -1,0 +1,48 @@
+import json
+import os
+import sys
+import types
+from pathlib import Path
+import importlib
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+class DummyExecutor:
+    def __init__(self):
+        self.called = []
+
+    def entry(self, signal):
+        self.called.append(signal)
+
+
+class DummyClient:
+    def __init__(self, price=10.0):
+        self.price = price
+
+    def ticker(self, markets):
+        return [{"market": m, "trade_price": self.price} for m in markets]
+
+
+def test_execute_buy_list(tmp_path, monkeypatch):
+    pandas_stub = types.ModuleType("pandas")
+    pandas_stub.Series = object
+    pandas_stub.DataFrame = object
+    monkeypatch.setitem(sys.modules, "pandas", pandas_stub)
+    monkeypatch.setitem(sys.modules, "f2_signal.signal_engine", types.ModuleType("f2_signal.signal_engine"))
+
+    ble = importlib.import_module("f2_signal.buy_list_executor")
+
+    data = [{"symbol": "KRW-BTC", "buy_signal": 1}]
+    (tmp_path / "f2_f2_realtime_buy_list.json").write_text(json.dumps(data))
+
+    monkeypatch.setattr(ble, "CONFIG_DIR", Path(tmp_path))
+    executor = DummyExecutor()
+    monkeypatch.setattr(ble, "OrderExecutor", lambda: executor)
+    monkeypatch.setattr(ble, "UpbitClient", lambda: DummyClient(100.0))
+
+    result = ble.execute_buy_list()
+
+    assert result == ["KRW-BTC"]
+    assert executor.called
+    assert executor.called[0]["price"] == 100.0


### PR DESCRIPTION
## Summary
- add a module to execute buy orders from `f2_f2_realtime_buy_list.json`
- document how to use the buy list executor
- test the new module

## Testing
- `pytest -q`