### PR TITLE
Enforce buy count and disable trailing stop

### DIFF
--- a/config/f4_f2_risk_settings.json
+++ b/config/f4_f2_risk_settings.json
@@ -21,7 +21,7 @@
 
   "SL_PCT": 1.0,
   "TP_PCT": 1.2,
-  "TRAILING_STOP_ENABLED": true,
+  "TRAILING_STOP_ENABLED": false,
   "TRAIL_START_PCT": 0.7,
   "TRAIL_STEP_PCT": 1.0
   ,"HOLD_SECS": 0

--- a/config/setting_date/f4_f3_default_config.json
+++ b/config/setting_date/f4_f3_default_config.json
@@ -16,7 +16,7 @@
   "AUTO_STOP_ENABLED": true,
   "SL_PCT": 2.5,
   "TP_PCT": 4.5,
-  "TRAILING_STOP_ENABLED": true,
+  "TRAILING_STOP_ENABLED": false,
   "TRAIL_START_PCT": 4.0,
   "TRAIL_STEP_PCT": 1.0
   ,"HOLD_SECS": 0

--- a/config/setting_date/f4_f3_latest_config.json
+++ b/config/setting_date/f4_f3_latest_config.json
@@ -16,7 +16,7 @@
   "AUTO_STOP_ENABLED": true,
   "SL_PCT": 2.5,
   "TP_PCT": 4.5,
-  "TRAILING_STOP_ENABLED": true,
+  "TRAILING_STOP_ENABLED": false,
   "TRAIL_START_PCT": 4.0,
   "TRAIL_STEP_PCT": 1.0
   ,"HOLD_SECS": 0

--- a/config/setting_date/f4_f3_ml_config.json
+++ b/config/setting_date/f4_f3_ml_config.json
@@ -16,7 +16,7 @@
   "AUTO_STOP_ENABLED": true,
   "SL_PCT": 2.0,
   "TP_PCT": 5.0,
-  "TRAILING_STOP_ENABLED": true,
+  "TRAILING_STOP_ENABLED": false,
   "TRAIL_START_PCT": 5.0,
   "TRAIL_STEP_PCT": 1.5
   ,"HOLD_SECS": 0

--- a/config/setting_date/f4_f3_yesterday_config.json
+++ b/config/setting_date/f4_f3_yesterday_config.json
@@ -16,7 +16,7 @@
   "AUTO_STOP_ENABLED": false,
   "SL_PCT": 3.0,
   "TP_PCT": 4.0,
-  "TRAILING_STOP_ENABLED": true,
+  "TRAILING_STOP_ENABLED": false,
   "TRAIL_START_PCT": 3.5,
   "TRAIL_STEP_PCT": 1.2
   ,"HOLD_SECS": 0

--- a/doc/02_coin_buy_logic.md
+++ b/doc/02_coin_buy_logic.md
@@ -31,8 +31,10 @@
 ### `run()`
 1. 모니터링 목록을 읽어 각 코인에 대해 `check_buy_signal()`을 수행합니다.
 2. 조건을 만족한 코인은 `[symbol, buy_signal, rsi_sel, trend_sel, buy_count]`
-   정보를 `f2_f2_realtime_buy_list.json`에 저장합니다. 매도 설정 리스트는
-   실제 매수가 완료된 뒤 별도의 과정에서 갱신됩니다.
+   정보를 `f2_f2_realtime_buy_list.json`에 저장합니다. 여기서 ``buy_count``
+   값이 0인 항목만이 매수 후보가 되며, 체결되면 값이 1로 갱신되어 중복
+   매수를 방지합니다. 매도 설정 리스트는 실제 매수가 완료된 뒤 별도의
+   과정에서 갱신됩니다.
 3. 과정과 결과는 `logs/f2_ml_buy_signal.log`에 기록됩니다.
 
 ### `f2_signal(df_1m, df_5m, symbol="", ...)`

--- a/doc/03_coin_sell_logic.md
+++ b/doc/03_coin_sell_logic.md
@@ -25,7 +25,7 @@ F3 모듈과 F4 리스크 매니저가 담당합니다.
 
 ### `PositionManager.hold_loop()`
 초당 실행되며 각 포지션의 현재가를 가져와 손익률을 계산합니다.
-손절(`SL_PCT`), 익절(`TP_PCT`), 트레일링 스탑(`TRAIL_*`) 기준을 만족하면
+손절(`SL_PCT`)과 익절(`TP_PCT`) 기준을 만족하면
 `execute_sell()`을 호출합니다.
 
 ### `PositionManager.execute_sell(position, exit_type, qty=None)`
@@ -40,8 +40,10 @@ F3 모듈과 F4 리스크 매니저가 담당합니다.
 
 1. `signal_loop.py`는 보유 중인 각 코인에 대해 `f2_signal(calc_sell=True)`을 호출합니다.
 2. `sell_signal`이 `True`이면 `PositionManager.execute_sell()`이 실행되어 시장가 주문을 보냅니다.
-3. 동시에 `hold_loop()`는 매초 손익을 계산하여 손절/익절/트레일링 스탑 기준을 만족하면 자동으로 매도합니다.
-4. 리스크 매니저가 손실 한도 초과를 감지하면 모든 포지션을 강제 정리하고
+3. 매수 주문이 체결되면 `OrderExecutor`가 `config/f2_f2_realtime_sell_list.json`에
+   해당 코인의 익절(`TP_PCT`)과 손절(`SL_PCT`) 값을 기록합니다.
+4. 동시에 `hold_loop()`는 매초 손익을 계산하여 손절/익절 조건을 만족하면 자동으로 매도합니다.
+5. 리스크 매니저가 손실 한도 초과를 감지하면 모든 포지션을 강제 정리하고
    상태를 `PAUSE` 또는 `HALT`로 변경합니다.
 
 이렇게 신호 기반 매도와 위험 관리 로직이 결합되어

--- a/doc/config.md
+++ b/doc/config.md
@@ -22,7 +22,9 @@ and continuously updated by the **F3** order executor.
 ## f2_f2_realtime_buy_list.json
 List of dictionaries produced by **F2** when a coin meets the ML and indicator
 conditions. Each entry contains `symbol`, `buy_signal`, `rsi_sel`, `trend_sel`,
-and `buy_count`.
+and `buy_count`. Only items where `buy_signal` is 1 and `buy_count` is 0 are
+considered for new orders. Once a buy is filled the count changes to 1 to
+prevent duplicate entries.
 
 ## f2_f2_realtime_sell_list.json
 Stores `thresh_pct` and `loss_pct` for each symbol after a buy order is filled.

--- a/doc/f2_ml_buy_signal.md
+++ b/doc/f2_ml_buy_signal.md
@@ -29,7 +29,7 @@
    ```
 
     모든 코인의 상태가 매 실행마다 덮어쓰기 되며,
-    `buy_signal` 값이 `1`인 항목만이 실제 매수 후보가 됩니다.
+    `buy_signal` 값이 `1`이고 `buy_count`가 `0`인 항목만이 실제 매수 후보가 됩니다.
 3. 결과와 과정을 모두 `logs/f2_ml_buy_signal.log`에 기록합니다.
 
 ### `check_buy_signal(symbol)`

--- a/f3_order/order_executor.py
+++ b/f3_order/order_executor.py
@@ -5,6 +5,8 @@ from .position_manager import PositionManager
 from .kpi_guard import KPIGuard
 from .exception_handler import ExceptionHandler
 from .utils import load_config, log_with_tag
+import json
+from pathlib import Path
 
 logger = logging.getLogger("F3_order_executor")
 fh = RotatingFileHandler(
@@ -45,6 +47,75 @@ class OrderExecutor:
         if entry_size is not None:
             self.config["ENTRY_SIZE_INITIAL"] = entry_size
 
+    def _mark_buy_filled(self, symbol: str) -> None:
+        """Set ``buy_count`` to 1 for the given symbol in the buy list."""
+        path = Path("config") / "f2_f2_realtime_buy_list.json"
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, list):
+                return
+        except Exception:
+            return
+
+        changed = False
+        for item in data:
+            if item.get("symbol") == symbol:
+                if item.get("buy_count", 0) != 1:
+                    item["buy_count"] = 1
+                    changed = True
+                break
+        if changed:
+            try:
+                with open(path, "w", encoding="utf-8") as f:
+                    json.dump(data, f, ensure_ascii=False, indent=2)
+            except Exception:
+                pass
+
+    def _update_realtime_sell_list(self, symbol: str) -> None:
+        """Add TP/SL info for *symbol* to the realtime sell list."""
+        sell_path = Path("config") / "f2_f2_realtime_sell_list.json"
+        mon_path = Path("config") / "f5_f1_monitoring_list.json"
+
+        try:
+            with open(sell_path, "r", encoding="utf-8") as f:
+                sell_data = json.load(f)
+            if not isinstance(sell_data, dict):
+                sell_data = {}
+        except Exception:
+            sell_data = {}
+
+        if symbol in sell_data:
+            return
+
+        try:
+            with open(mon_path, "r", encoding="utf-8") as f:
+                mon_list = json.load(f)
+        except Exception:
+            return
+
+        thresh = None
+        loss = None
+        if isinstance(mon_list, list):
+            for item in mon_list:
+                if isinstance(item, dict) and item.get("symbol") == symbol:
+                    thresh = item.get("thresh_pct")
+                    loss = item.get("loss_pct")
+                    break
+        if thresh is None or loss is None:
+            return
+
+        sell_data[symbol] = {
+            "TP_PCT": float(thresh) * 100,
+            "SL_PCT": float(loss) * 100,
+        }
+
+        try:
+            with open(sell_path, "w", encoding="utf-8") as f:
+                json.dump(sell_data, f, ensure_ascii=False, indent=2)
+        except Exception:
+            pass
+
     def entry(self, signal):
         """F2 신호 딕셔너리 → smart_buy 주문 (filled시 포지션 오픈)"""
         try:
@@ -74,6 +145,8 @@ class OrderExecutor:
                     if signal.get("buy_triggers"):
                         order_result["strategy"] = signal["buy_triggers"][0]
                     self.position_manager.open_position(order_result)
+                    self._update_realtime_sell_list(symbol)
+                    self._mark_buy_filled(symbol)
                     log_with_tag(logger, f"Buy executed: {order_result}")
                     msg = (
                         f"BUY {order_result['symbol']} {order_result.get('qty')}"

--- a/tests/test_buy_list_executor.py
+++ b/tests/test_buy_list_executor.py
@@ -33,7 +33,7 @@ def test_execute_buy_list(tmp_path, monkeypatch):
 
     ble = importlib.import_module("f2_signal.buy_list_executor")
 
-    data = [{"symbol": "KRW-BTC", "buy_signal": 1}]
+    data = [{"symbol": "KRW-BTC", "buy_signal": 1, "buy_count": 0}]
     (tmp_path / "f2_f2_realtime_buy_list.json").write_text(json.dumps(data))
 
     monkeypatch.setattr(ble, "CONFIG_DIR", Path(tmp_path))
@@ -46,3 +46,5 @@ def test_execute_buy_list(tmp_path, monkeypatch):
     assert result == ["KRW-BTC"]
     assert executor.called
     assert executor.called[0]["price"] == 100.0
+    after = json.loads((tmp_path / "f2_f2_realtime_buy_list.json").read_text())
+    assert after[0]["buy_count"] == 1


### PR DESCRIPTION
## Summary
- only execute buys when `buy_signal` == 1 and `buy_count` == 0
- mark buys as filled in `f2_f2_realtime_buy_list.json`
- update `OrderExecutor` to sync buy list and sell list on fills
- disable trailing stop defaults and update docs
- test coverage for new buy list logic

## Testing
- `pytest -q`