### PR TITLE
Implement Telegram remote control

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Any issues loading credentials are recorded in `logs/F3_utils.log`.
 When credentials are set, brief buy/sell notifications are sent through
 Telegram whenever orders are executed. See
 [doc/telegram_notifications.md](doc/telegram_notifications.md).
+Remote start/stop commands are documented in
+[doc/telegram_remote_control.md](doc/telegram_remote_control.md).
 
 Startup messages about credential loading are written to `logs/F3_utils.log`.
 Check this file if account queries fail to verify that API keys were detected.

--- a/doc/telegram_remote_control.md
+++ b/doc/telegram_remote_control.md
@@ -1,0 +1,12 @@
+# Telegram Remote Control
+
+`f4_setting.telegram_control` provides a small Telegram bot to start and stop the
+trading loop remotely.
+
+1. Create a bot with `@BotFather` and note the token.
+2. Set the `TELEGRAM_TOKEN` environment variable with the token.
+3. Run `f4_setting.telegram_control.start_bot()` to begin polling.
+
+Use `/on` or `/off` in the chat. The bot writes `server_status.txt` with `ON` or
+`OFF`. `signal_loop.main_loop` reads this file each cycle and only operates when
+the status is `ON`.

--- a/f4_setting/telegram_control.py
+++ b/f4_setting/telegram_control.py
@@ -1,0 +1,44 @@
+import os
+
+try:
+    import telebot
+except Exception:  # pragma: no cover - optional dependency
+    telebot = None
+
+TOKEN = os.environ.get("TELEGRAM_TOKEN")
+STATUS_FILE = "server_status.txt"
+
+bot = telebot.TeleBot(TOKEN) if telebot and TOKEN else None
+
+def write_status(state: str) -> None:
+    """Write ON/OFF state to the status file."""
+    with open(STATUS_FILE, "w", encoding="utf-8") as f:
+        f.write(state)
+
+def read_status() -> str:
+    """Return current server state, defaults to OFF if file missing."""
+    try:
+        with open(STATUS_FILE, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return "OFF"
+
+if bot:
+    @bot.message_handler(commands=["on"])
+    def _handle_on(message):
+        write_status("ON")
+        bot.reply_to(message, "서버를 ON 했습니다.")
+
+    @bot.message_handler(commands=["off"])
+    def _handle_off(message):
+        write_status("OFF")
+        bot.reply_to(message, "서버를 OFF 했습니다.")
+
+    @bot.message_handler(func=lambda m: True)
+    def _handle_unknown(message):
+        bot.reply_to(message, "명령어를 인식하지 못했습니다.\n/on 또는 /off를 사용하세요.")
+
+def start_bot() -> None:
+    """Start polling if telebot is available and token set."""
+    if bot:
+        bot.polling()

--- a/signal_loop.py
+++ b/signal_loop.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from f3_order.order_executor import entry as f3_entry, _default_executor
 from f4_riskManager import RiskManager
+from f4_setting.telegram_control import read_status
 
 import pyupbit
 
@@ -121,6 +122,13 @@ def main_loop(interval: int = 1, stop_event=None) -> None:
     risk_manager = RiskManager(order_executor=executor, exception_handler=executor.exception_handler)
     executor.set_risk_manager(risk_manager)
     while True:
+        if read_status().upper() != "ON":
+            logging.info("[Loop] Waiting for ON status...")
+            executor.manage_positions()
+            time.sleep(5)
+            if stop_event and stop_event.is_set():
+                break
+            continue
         if stop_event and stop_event.is_set():
             break
         universe = get_universe()

--- a/tests/test_telegram_control.py
+++ b/tests/test_telegram_control.py
@@ -1,0 +1,16 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from f4_setting.telegram_control import read_status, write_status
+
+
+def test_read_status_defaults_to_off(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    assert read_status() == "OFF"
+
+
+def test_write_and_read_status(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_status("ON")
+    assert read_status() == "ON"


### PR DESCRIPTION
## Summary
- add `telegram_control` module under new `f4_setting` package
- check `server_status.txt` from `signal_loop`
- document remote control usage and reference it from README
- test reading and writing the status file

## Testing
- `pytest -q`