### PR TITLE
Streamline feature engineering indicators

### DIFF
--- a/doc/f5ml_feature_engineering.md
+++ b/doc/f5ml_feature_engineering.md
@@ -8,23 +8,18 @@
 처리됩니다.
 
 ## 추가되는 지표
-- `ema5`: 5분 지수이동평균
-- `ema20`: 20분 지수이동평균
-- `sma5`, `sma20`: 단순 이동평균
-- `rsi14`: 14분 상대강도지수
+- `ema5`, `ema13`, `ema20`, `ema60`, `ema120`: 지수이동평균
+- `rsi14`: 14분 상대강도지수 및 과매수/과매도 플래그
 - `atr14`: 14분 평균진폭
-- `vol_ratio`: 최근 거래량 대비 비율
-- `stoch_k`, `stoch_d`: 스토캐스틱(14,3)
+- `pct_change_1m`, `pct_change_5m`, `pct_change_10m`: 가격 변동률
+- `vol_ratio`, `vol_ratio_5`: 거래량 비율과 증감률
+- `stoch_k14`, `stoch_d14`: 스토캐스틱(14,3)
 - `macd`, `macd_signal`, `macd_hist`: MACD(12,26,9)
 - `mfi14`: 14분 자금 흐름 지수
 - `adx14`: 14분 ADX 추세 강도
-- `bb_mid`, `bb_upper`, `bb_lower`: 볼린저 밴드
-- `mom10`, `roc10`: 모멘텀/ROC
-- `cci14`: 상품 채널 지수
-- `vwap`: 거래량 가중 평균가
+- `bb_mid`, `bb_upper`, `bb_lower`, `bb_width`, `bb_dist`: 볼린저 밴드 지표
 - `obv`: 온밸런스 볼륨
-- `volatility14`: 14분 표준편차
-- `anomaly`: 급등락 탐지 플래그
+- 여러 캔들 패턴과 시간 관련 파생 컬럼
 
 실행 후 각 심볼별 `{symbol}_feature.parquet` 파일이 생성됩니다.
 모든 스크립트는 자기 디렉터리 기준 절대 경로를 사용하므로 실행 위치와 관계없이 `f5_ml_pipeline/ml_data/` 하위에 결과가 저장됩니다.

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -32,9 +32,10 @@ def test_add_features_basic():
     }
     df = pd.DataFrame(data)
     result = feature_engineering.add_features(df)
-    for col in ["ema5", "ema20", "rsi14", "atr14", "vol_ratio", "stoch_k"]:
+    for col in ["ema5", "ema13", "ema20", "rsi14", "atr14", "vol_ratio", "stoch_k14"]:
         assert col in result.columns
     assert "ma_vol20" not in result.columns
+    assert "ema8" not in result.columns
 
 
 @pytest.mark.skipif(not pandas_available, reason="pandas not available")


### PR DESCRIPTION
## Summary
- simplify indicator set in `03_feature_engineering.py`
- update test expectations for new columns
- document streamlined feature list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844561593ac8329b492387b3ff044e9