### PR TITLE
Update docs for f2_buy_signal alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ python signal_loop.py
 로그는 `logs/F1-F2_loop.log`에 기록되며, 용량이 100MB를 넘으면 자동으로 회전합니다. 독립적인 ML 매수 신호 루틴을 실행하려면 프로젝트 루트에서 다음과 같이 실행하세요.
 
 ```bash
-python -m f2_ml_buy_signal.02_ml_buy_signal
+python -m f2_buy_signal.02_ml_buy_signal
 ```
 
 결과는 `logs/f2/f2_ml_buy_signal.log`에 저장됩니다. 필요한 패키지가 없으면 이 로그 파일에 오류도 기록됩니다.
@@ -70,7 +70,7 @@ python app.py
 서버는 포트 3000에서 동작하며 `http://localhost:3000`으로 접속할 수 있습니다.
 서버 시작 시 다음 세 가지 백그라운드 작업이 실행됩니다.
 - `f5_ml_pipeline/01_data_collect.py` : 1분봉 OHLCV 데이터를 지속적으로 수집합니다.
-- `f2_ml_buy_signal/02_ml_buy_signal.py` : 15초마다 실시간 매수 목록을 갱신합니다.
+- `f2_buy_signal/02_ml_buy_signal.py` : F5 예측 결과가 갱신될 때마다 실시간 매수 목록을 갱신합니다.
 - `f5_ml_pipeline/run_pipeline.py` : 5분마다 모델을 재학습하고 평가합니다.
 
 ## 자격 증명 설정

--- a/doc/00_auto_upbit.md
+++ b/doc/00_auto_upbit.md
@@ -26,7 +26,7 @@ flowchart TD
 
 ## 2. F2 실시간 매수 신호
 - **역할**: 최근 1분봉 데이터를 이용해 머신러닝으로 매수 가능성을 판단합니다.
-- **주요 파일**: `f2_ml_buy_signal/02_ml_buy_signal.py`, `f2_ml_buy_signal/01_buy_indicator.py`, `f2_ml_buy_signal/03_buy_signal_engine/signal_engine.py`
+- **주요 파일**: `f2_buy_signal/02_ml_buy_signal.py`, `f2_buy_signal/01_buy_indicator.py`, `f2_buy_signal/03_buy_signal_engine/signal_engine.py`
 - **주요 함수**
   - `run()` – 모니터링 리스트를 순회하며 매수 신호 계산 【F:f2_ml_buy_signal/02_ml_buy_signal.py†L323-L392】
   - `run_if_monitoring_list_exists()` – 모니터링 파일이 있을 때만 실행 【F:f2_ml_buy_signal/02_ml_buy_signal.py†L395-L401】
@@ -59,7 +59,7 @@ flowchart TD
 ## 동작 흐름 요약
 1. **전략 선별(F5)**에서 추천된 코인이 `config/f5_f1_monitoring_list.json`에 저장됩니다.
 2. **유니버스 선택(F1)**이 주기적으로 실행되어 모니터링 코인을 결정하고 `config/current_universe.json`에 기록합니다.
-3. **신호 계산(F2)**이 `signal_loop.py`에서 15초 주기로 호출되어 각 코인의 매수/매도 신호를 구합니다.
+3. **신호 계산(F2)**은 F5 파이프라인의 예측 결과가 생성될 때마다 실행되어 각 코인의 매수/매도 신호를 구합니다.
 4. **주문 실행(F3)**이 신호를 받아 주문을 전송하고, 포지션 정보를 `config/f1_f3_coin_positions.json`에 업데이트합니다.
 5. 전체 과정은 **웹 대시보드**에서 실시간으로 조회 가능하며, 텔레그램 알림과 원격 제어 기능(F6)이 지원됩니다.
 

--- a/doc/02_coin_buy_logic.md
+++ b/doc/02_coin_buy_logic.md
@@ -8,10 +8,10 @@
 
 | 경로 | 용도 |
 | --- | --- |
-| `f2_ml_buy_signal/02_ml_buy_signal.py` | 경량 머신러닝으로 실시간 매수 신호를 판단합니다. |
-| `f2_ml_buy_signal/01_buy_indicator.py` | 1분 봉에서 RSI와 EMA 조건을 이용한 간단한 매수 필터 함수가 있습니다. |
-| `f2_ml_buy_signal/f2_data/` | 단계별 임시 Parquet 파일 저장 위치. 신호 계산 후 폴더 전체가 삭제됩니다. |
-| `f2_ml_buy_signal/03_buy_signal_engine/signal_engine.py` | `f2_signal()` 함수에서 1분 봉 데이터를 받아 ML 모델을 호출합니다. |
+| `f2_buy_signal/02_ml_buy_signal.py` | 경량 머신러닝으로 실시간 매수 신호를 판단합니다. |
+| `f2_buy_signal/01_buy_indicator.py` | 1분 봉에서 RSI와 EMA 조건을 이용한 간단한 매수 필터 함수가 있습니다. |
+| `f2_buy_signal/f2_data/` | 단계별 임시 Parquet 파일 저장 위치. 신호 계산 후 폴더 전체가 삭제됩니다. |
+| `f2_buy_signal/03_buy_signal_engine/signal_engine.py` | `f2_signal()` 함수에서 1분 봉 데이터를 받아 ML 모델을 호출합니다. |
 | `f3_order/order_executor.py` | 매수 신호를 받아 주문을 실행하는 `OrderExecutor` 클래스가 있습니다. |
 | `f3_order/position_manager.py` | 포지션을 저장·관리하며 주문 결과를 기록합니다. |
 | `config/f5_f1_monitoring_list.json` | 모니터링할 코인 목록(`symbol`, `thresh_pct`, `loss_pct`). F5 단계에서 생성됩니다. |
@@ -75,14 +75,14 @@
 
 ## 실시간 매수 리스트 활용
 
-`f2_ml_buy_signal.run()`이 작성한 `config/f2_f2_realtime_buy_list.json`은
-웹 서버의 스케줄러가 15초마다 자동으로 읽어 주문을 실행합니다. 구현은
+`f2_buy_signal.run()`이 작성한 `config/f2_f2_realtime_buy_list.json`은
+F5 예측 결과가 업데이트될 때마다 자동으로 읽어 주문을 실행합니다. 구현은
 `buy_list_executor.execute_buy_list()`를 호출하는 방식이며, 매수 후보가 있으면
 즉시 `OrderExecutor.entry()`로 전달됩니다. 필요하다면 아래와 같이 수동으로도
 실행할 수 있습니다.
 
 ```python
-from f2_ml_buy_signal.03_buy_signal_engine.buy_list_executor import execute_buy_list
+from f2_buy_signal.03_buy_signal_engine.buy_list_executor import execute_buy_list
 execute_buy_list()
 ```
 

--- a/doc/02_coin_buy_signal.md
+++ b/doc/02_coin_buy_signal.md
@@ -9,15 +9,15 @@
 ## 사용되는 관련 파일
 | 경로 | 설명 |
 | --- | --- |
-| `f2_ml_buy_signal/02_ml_buy_signal.py` | 전체 파이프라인과 실시간 예측 로직을 포함합니다. |
-| `f2_ml_buy_signal/01_buy_indicator.py` | EMA와 RSI 기반의 기본 필터 함수를 제공합니다. |
+| `f2_buy_signal/02_ml_buy_signal.py` | 전체 파이프라인과 실시간 예측 로직을 포함합니다. |
+| `f2_buy_signal/01_buy_indicator.py` | EMA와 RSI 기반의 기본 필터 함수를 제공합니다. |
 | `config/f5_f1_monitoring_list.json` | 매수 신호를 계산할 코인 목록입니다. |
 | `config/f2_f2_realtime_buy_list.json` | 계산된 매수 신호가 저장되는 파일입니다. |
 | `logs/f2/f2_ml_buy_signal.log` | 매수 신호 계산 과정의 로그가 기록됩니다. |
 
 ## 사용되는 함수
 - `run_if_monitoring_list_exists()` – 모니터링 목록이 존재할 때만 `run()`을 호출합니다. 【F:f2_ml_buy_signal/02_ml_buy_signal.py†L361-L371】
-- `run()` – 각 코인에 대해 `check_buy_signal()`을 호출하고 결과를 JSON 파일에 기록합니다. 【F:f2_ml_buy_signal/02_ml_buy_signal.py†L322-L359】
+- `f2_buy_signal.run()` – 각 코인에 대해 `check_buy_signal()`을 호출하고 결과를 JSON 파일에 기록합니다. 【F:f2_ml_buy_signal/02_ml_buy_signal.py†L322-L359】
 - `check_buy_signal()` – 모델 예측 값과 지표 조건을 확인하여 `(buy, rsi_flag, trend_flag)`를 반환합니다. 【F:f2_ml_buy_signal/02_ml_buy_signal.py†L256-L303】
 
 ## 동작 흐름

--- a/doc/03_coin_sell_logic.md
+++ b/doc/03_coin_sell_logic.md
@@ -8,7 +8,7 @@ F3 모듈과 간단한 위험 관리 로직이 담당합니다.
 
 | 경로 | 설명 |
 | --- | --- |
-| `f2_ml_buy_signal/03_buy_signal_engine/signal_engine.py` | `f2_signal()` 함수가 매도 공식을 평가합니다. |
+| `f2_buy_signal/03_buy_signal_engine/signal_engine.py` | `f2_signal()` 함수가 매도 공식을 평가합니다. |
 | `f3_order/position_manager.py` | 포지션 정보를 저장하고 `hold_loop()`에서 손익을 주기적으로 계산합니다. |
 | `f3_order/order_executor.py` | `manage_positions()` 메서드로 포지션 상태를 점검하고 필요 시 매도를 실행합니다. |
 | `config/f6_buy_settings.json` | 진입 금액과 동시 보유 코인 수 등을 지정하는 설정 파일입니다. |

--- a/doc/f2_ml_buy_signal.md
+++ b/doc/f2_ml_buy_signal.md
@@ -1,6 +1,6 @@
 # F2 경량 ML 매수 신호
 
-`f2_ml_buy_signal/02_ml_buy_signal.py`는 실시간 매수를 위한 경량 머신러닝 파이프라인입니다.
+`f2_buy_signal/02_ml_buy_signal.py`는 실시간 매수를 위한 경량 머신러닝 파이프라인입니다.
 업비트 1분봉 데이터를 읽어 F5 파이프라인에서 학습된 모델을 이용해 **매수 신호 여부**만 빠르게 판단합니다.
 
 ## 주요 경로
@@ -9,7 +9,7 @@
 | --- | --- |
 | `config/f5_f1_monitoring_list.json` | 모니터링할 코인 목록. 목록이 없으면 스크립트가 실행되지 않습니다. |
 | `logs/f2/f2_ml_buy_signal.log` | 전체 과정의 로그가 저장되는 파일. |
-| `f2_ml_buy_signal/f2_data/` | 단계별 중간 데이터가 저장되는 임시 폴더. 실행이 끝나면 자동으로 삭제됩니다. |
+| `f2_buy_signal/f2_data/` | 단계별 중간 데이터가 저장되는 임시 폴더. 실행이 끝나면 자동으로 삭제됩니다. |
 
 ## 핵심 함수
 
@@ -40,7 +40,7 @@
 
 ## 동작 순서
 
-1. `signal_loop.py` 혹은 상위 스케줄러가 15초 주기로 `run_if_monitoring_list_exists()`를 호출합니다.
+1. `f5_ml_pipeline`의 예측 결과가 갱신되면 `run_if_monitoring_list_exists()`가 자동으로 호출됩니다.
 2. 스크립트는 `f5_f1_monitoring_list.json`이 존재할 때만 각 코인의 매수 신호를 판별합니다.
 3. 매수 신호가 `True`로 판단되면 해당 코인이 실시간 매수 리스트에만 기록됩니다.
    실제 주문이 체결된 뒤에야 별도의 로직이 매도 설정 리스트(`f3_f3_realtime_sell_list.json`)
@@ -54,5 +54,5 @@
 레포지터리 루트에서 모듈 형태로 실행하면 import 오류 없이 동작합니다.
 
 ```bash
-python -m f2_ml_buy_signal.02_ml_buy_signal
+python -m f2_buy_signal.02_ml_buy_signal
 ```

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -1,13 +1,13 @@
 # 주문 실행 문제 해결
 
-이 문서는 `f2_ml_buy_signal.run()` 실행 이후 `config/f2_f2_realtime_buy_list.json`이 갱신되었는데도
+이 문서는 `f2_buy_signal.run()` 실행 이후 `config/f2_f2_realtime_buy_list.json`이 갱신되었는데도
 주문이 이루어지지 않을 때 확인할 항목을 정리합니다. 각 단계별 로그 확인 방법과 단위 테스트
 실행 방법을 함께 소개합니다.
 
 ## 기본 흐름
-1. `f2_ml_buy_signal/02_ml_buy_signal.py`의 `run()` 함수가 모니터링 중인 코인을 순회하며
+1. `f2_buy_signal/02_ml_buy_signal.py`의 `run()` 함수가 모니터링 중인 코인을 순회하며
     매수 신호를 계산하고 결과를 `config/f2_f2_realtime_buy_list.json`에 저장합니다.
-2. `app.py`의 `start_buy_signal_scheduler()`가 15초마다 위 파일을 읽어
+2. `app.py`에서 F5 예측 결과가 생성될 때마다 해당 파일을 읽어
     `buy_list_executor.execute_buy_list()`를 호출합니다.
 3. `buy_list_executor.execute_buy_list()`는 매수 가능한 항목을 필터링한 뒤 현재 가격을 조회하고
     `OrderExecutor.entry()`로 전달합니다.
@@ -27,7 +27,7 @@
 
 - **2단계: 스케줄러 동작 여부**
 
-`app.py`를 실행하면 스케줄러 스레드가 생성되어 15초마다 실행됩니다.
+`app.py`를 실행하면 스케줄러 스레드가 생성되어 F5 예측 결과가 업데이트될 때마다 실행됩니다.
 `logs/etc/web.log`에서 다음과 같은 메시지를 확인합니다.
 
     ```text

--- a/f2_buy_signal/01_buy_indicator.py
+++ b/f2_buy_signal/01_buy_indicator.py
@@ -1,0 +1,4 @@
+from importlib import import_module as _im
+import sys
+module = _im('f2_ml_buy_signal.01_buy_indicator')
+sys.modules[__name__] = module

--- a/f2_buy_signal/02_ml_buy_signal.py
+++ b/f2_buy_signal/02_ml_buy_signal.py
@@ -1,0 +1,4 @@
+from importlib import import_module as _im
+import sys
+module = _im('f2_ml_buy_signal.02_ml_buy_signal')
+sys.modules[__name__] = module

--- a/f2_buy_signal/03_buy_signal_engine/__init__.py
+++ b/f2_buy_signal/03_buy_signal_engine/__init__.py
@@ -1,0 +1,4 @@
+from importlib import import_module as _im
+import sys
+module = _im('f2_ml_buy_signal.03_buy_signal_engine')
+sys.modules[__name__] = module

--- a/f2_buy_signal/__init__.py
+++ b/f2_buy_signal/__init__.py
@@ -1,0 +1,13 @@
+from importlib import import_module
+import sys
+
+_submodules = {"01_buy_indicator", "02_ml_buy_signal", "03_buy_signal_engine"}
+
+def __getattr__(name):
+    if name in _submodules:
+        module = import_module(f"f2_ml_buy_signal.{name}")
+        sys.modules[f"{__name__}.{name}"] = module
+        return module
+    raise AttributeError(f"module {__name__} has no attribute {name}")
+
+__all__ = list(_submodules)

--- a/tests/test_app_endpoints.py
+++ b/tests/test_app_endpoints.py
@@ -21,6 +21,7 @@ def app_client(monkeypatch):
         }
     stub.f2_signal = fake_f2_signal
     stub.reload_strategy_settings = lambda: None
+    monkeypatch.setitem(sys.modules, "f2_buy_signal.03_buy_signal_engine.signal_engine", stub)
     monkeypatch.setitem(sys.modules, "f2_ml_buy_signal.03_buy_signal_engine.signal_engine", stub)
 
     # Provide a dummy pyupbit module

--- a/tests/test_buy_list_executor.py
+++ b/tests/test_buy_list_executor.py
@@ -34,7 +34,12 @@ def test_execute_buy_list(tmp_path, monkeypatch):
     pandas_stub.DataFrame = object
     monkeypatch.setitem(sys.modules, "pandas", pandas_stub)
     engine_mod = types.ModuleType(
-        "f2_ml_buy_signal.03_buy_signal_engine.signal_engine"
+        "f2_buy_signal.03_buy_signal_engine.signal_engine"
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "f2_buy_signal.03_buy_signal_engine.signal_engine",
+        engine_mod,
     )
     monkeypatch.setitem(
         sys.modules,
@@ -42,7 +47,7 @@ def test_execute_buy_list(tmp_path, monkeypatch):
         engine_mod,
     )
 
-    ble = importlib.import_module("f2_ml_buy_signal.03_buy_signal_engine.buy_list_executor")
+    ble = importlib.import_module("f2_buy_signal.03_buy_signal_engine.buy_list_executor")
 
     data = [{"symbol": "KRW-BTC", "buy_signal": 1, "buy_count": 0, "pending": 0}]
     (tmp_path / "f2_f2_realtime_buy_list.json").write_text(json.dumps(data))
@@ -67,7 +72,12 @@ def test_execute_buy_list_orderbook_fallback(tmp_path, monkeypatch):
     pandas_stub.DataFrame = object
     monkeypatch.setitem(sys.modules, "pandas", pandas_stub)
     engine_mod = types.ModuleType(
-        "f2_ml_buy_signal.03_buy_signal_engine.signal_engine"
+        "f2_buy_signal.03_buy_signal_engine.signal_engine"
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "f2_buy_signal.03_buy_signal_engine.signal_engine",
+        engine_mod,
     )
     monkeypatch.setitem(
         sys.modules,
@@ -75,7 +85,7 @@ def test_execute_buy_list_orderbook_fallback(tmp_path, monkeypatch):
         engine_mod,
     )
 
-    ble = importlib.import_module("f2_ml_buy_signal.03_buy_signal_engine.buy_list_executor")
+    ble = importlib.import_module("f2_buy_signal.03_buy_signal_engine.buy_list_executor")
 
     data = [{"symbol": "KRW-ETH", "buy_signal": 1, "buy_count": 0, "pending": 0}]
     (tmp_path / "f2_f2_realtime_buy_list.json").write_text(json.dumps(data))
@@ -103,7 +113,12 @@ def test_execute_buy_list_string_flags(tmp_path, monkeypatch):
     pandas_stub.DataFrame = object
     monkeypatch.setitem(sys.modules, "pandas", pandas_stub)
     engine_mod = types.ModuleType(
-        "f2_ml_buy_signal.03_buy_signal_engine.signal_engine"
+        "f2_buy_signal.03_buy_signal_engine.signal_engine"
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "f2_buy_signal.03_buy_signal_engine.signal_engine",
+        engine_mod,
     )
     monkeypatch.setitem(
         sys.modules,
@@ -111,7 +126,7 @@ def test_execute_buy_list_string_flags(tmp_path, monkeypatch):
         engine_mod,
     )
 
-    ble = importlib.import_module("f2_ml_buy_signal.03_buy_signal_engine.buy_list_executor")
+    ble = importlib.import_module("f2_buy_signal.03_buy_signal_engine.buy_list_executor")
 
     data = [{"symbol": "KRW-XRP", "buy_signal": "1", "buy_count": "0", "pending": 0}]
     (tmp_path / "f2_f2_realtime_buy_list.json").write_text(json.dumps(data))

--- a/tests/test_manage_positions.py
+++ b/tests/test_manage_positions.py
@@ -22,8 +22,8 @@ def test_main_loop_invokes_hold_loop(monkeypatch):
     stub = types.ModuleType("signal_engine")
     stub.f2_signal = lambda *a, **k: {}
     stub.reload_strategy_settings = lambda: None
+    sys.modules["f2_buy_signal.03_buy_signal_engine.signal_engine"] = stub
     sys.modules["f2_ml_buy_signal.03_buy_signal_engine.signal_engine"] = stub
-
     import signal_loop
     importlib.reload(signal_loop)
 
@@ -53,6 +53,7 @@ def test_monitor_worker_invokes_hold_loop(monkeypatch):
     stub = types.ModuleType("signal_engine")
     stub.f2_signal = lambda *a, **k: {}
     stub.reload_strategy_settings = lambda: None
+    sys.modules["f2_buy_signal.03_buy_signal_engine.signal_engine"] = stub
     sys.modules["f2_ml_buy_signal.03_buy_signal_engine.signal_engine"] = stub
 
     import signal_loop

--- a/tests/test_ml_buy_list.py
+++ b/tests/test_ml_buy_list.py
@@ -47,7 +47,7 @@ def test_run_updates_buy_list_only(tmp_path, monkeypatch):
     })
 
     from importlib import import_module
-    ml = import_module("f2_ml_buy_signal.02_ml_buy_signal")
+    ml = import_module("f2_buy_signal.02_ml_buy_signal")
 
     monkeypatch.setattr(ml, "CONFIG_DIR", Path(cfg))
     monkeypatch.setattr(ml, "check_buy_signal", Dummy((True, True, True)))
@@ -100,7 +100,7 @@ def test_run_preserves_existing_buy_count(tmp_path, monkeypatch):
     })
 
     from importlib import import_module
-    ml = import_module("f2_ml_buy_signal.02_ml_buy_signal")
+    ml = import_module("f2_buy_signal.02_ml_buy_signal")
 
     monkeypatch.setattr(ml, "CONFIG_DIR", Path(cfg))
     monkeypatch.setattr(ml, "check_buy_signal", Dummy((True, True, True)))
@@ -145,7 +145,7 @@ def test_existing_sell_list_preserved(tmp_path, monkeypatch):
 
     from importlib import import_module
 
-    ml = import_module("f2_ml_buy_signal.02_ml_buy_signal")
+    ml = import_module("f2_buy_signal.02_ml_buy_signal")
 
     monkeypatch.setattr(ml, "CONFIG_DIR", Path(cfg))
     monkeypatch.setattr(ml, "check_buy_signal", Dummy((True, True, True)))
@@ -191,7 +191,7 @@ def test_old_sell_entry_untouched(tmp_path, monkeypatch):
 
     from importlib import import_module
 
-    ml = import_module("f2_ml_buy_signal.02_ml_buy_signal")
+    ml = import_module("f2_buy_signal.02_ml_buy_signal")
 
     monkeypatch.setattr(ml, "CONFIG_DIR", Path(cfg))
     monkeypatch.setattr(ml, "check_buy_signal", Dummy((True, True, True)))
@@ -232,7 +232,7 @@ def test_run_records_non_signals(tmp_path, monkeypatch):
     })
 
     from importlib import import_module
-    ml = import_module("f2_ml_buy_signal.02_ml_buy_signal")
+    ml = import_module("f2_buy_signal.02_ml_buy_signal")
 
     monkeypatch.setattr(ml, "CONFIG_DIR", Path(cfg))
     monkeypatch.setattr(ml, "check_buy_signal", Dummy((False, True, True)))
@@ -256,7 +256,7 @@ def test_run_records_non_signals(tmp_path, monkeypatch):
 
 def test_run_if_monitoring_skips_when_missing(tmp_path, monkeypatch):
     from importlib import import_module
-    ml = import_module("f2_ml_buy_signal.02_ml_buy_signal")
+    ml = import_module("f2_buy_signal.02_ml_buy_signal")
 
     monkeypatch.setattr(ml, "CONFIG_DIR", Path(tmp_path))
     called = {"cnt": 0}
@@ -274,7 +274,7 @@ def test_run_if_monitoring_skips_when_missing(tmp_path, monkeypatch):
 
 def test_run_if_monitoring_executes(tmp_path, monkeypatch):
     from importlib import import_module
-    ml = import_module("f2_ml_buy_signal.02_ml_buy_signal")
+    ml = import_module("f2_buy_signal.02_ml_buy_signal")
 
     monkeypatch.setattr(ml, "CONFIG_DIR", Path(tmp_path))
     (tmp_path / "f5_f1_monitoring_list.json").write_text("[]")

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -12,7 +12,7 @@ else:
 
 if pandas_available:
     from importlib import import_module
-    _mod = import_module("f2_ml_buy_signal.03_buy_signal_engine.signal_engine")
+    _mod = import_module("f2_buy_signal.03_buy_signal_engine.signal_engine")
     eval_formula = _mod.eval_formula
     f2_signal = _mod.f2_signal
 


### PR DESCRIPTION
## Summary
- document the new `f2_buy_signal` module throughout the docs
- update README instructions for the renamed package
- switch tests to import `f2_buy_signal`
- provide a lightweight `f2_buy_signal` package as alias

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445c95316c8329b2fce36cb24fbd6e