### PR TITLE
Add label and order tests

### DIFF
--- a/tests/test_labeling.py
+++ b/tests/test_labeling.py
@@ -58,3 +58,26 @@ def test_trailing_none_uses_basic():
     )
     res_basic = labeling.make_labels_basic(df, horizon=2, thresh_pct=0.003)
     assert list(res_trail["label"]) == list(res_basic["label"])
+
+
+@pytest.mark.skipif(not pandas_available, reason="pandas not available")
+def test_make_labels_trailing_multistage():
+    df = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2021-01-01", periods=6, freq="T"),
+            "open": [101, 102, 100, 101, 100, 100],
+            "high": [101, 102, 100, 101, 100, 100],
+            "low": [101, 102, 100, 101, 100, 100],
+            "close": [101, 102, 100, 101, 100, 100],
+            "volume": [1] * 6,
+        }
+    )
+    result = labeling.make_labels_trailing(
+        df,
+        horizon=2,
+        thresh_pct=0.01,
+        loss_pct=0.01,
+        trail_start_pct=0.005,
+        trail_down_pct=0.005,
+    )
+    assert list(result["label"][:4]) == [2, -1, 1, 0]

--- a/tests/test_signal_loop.py
+++ b/tests/test_signal_loop.py
@@ -32,3 +32,65 @@ def test_process_symbol_ignores_imported_strategy(monkeypatch):
     signal_loop.process_symbol("KRW-BTC")
     assert captured["codes"] is None
 
+
+@pytest.mark.skipif(not pandas_available, reason="pandas not available")
+def test_process_symbol_forwards_to_f3(monkeypatch):
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2021-01-01", periods=2, freq="T"),
+        "open": [1, 2],
+        "high": [1, 2],
+        "low": [1, 2],
+        "close": [1, 2],
+        "volume": [1, 1],
+    })
+
+    monkeypatch.setattr(signal_loop, "fetch_ohlcv", lambda *a, **k: df)
+
+    result_signal = {
+        "symbol": "KRW-AAA",
+        "buy_signal": True,
+        "sell_signal": False,
+        "buy_triggers": ["A"],
+        "sell_triggers": [],
+    }
+    monkeypatch.setattr(signal_loop, "f2_signal", lambda *a, **k: result_signal)
+    forwarded = {}
+    monkeypatch.setattr(signal_loop, "f3_entry", lambda sig: forwarded.setdefault("sig", sig))
+    signal_loop._default_executor.position_manager.positions = []
+
+    res = signal_loop.process_symbol("KRW-AAA")
+    assert forwarded.get("sig", {}).get("symbol") == "KRW-AAA"
+    assert res.get("price") == 2.0
+
+
+@pytest.mark.skipif(not pandas_available, reason="pandas not available")
+def test_process_symbol_executes_sell(monkeypatch):
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2021-01-01", periods=2, freq="T"),
+        "open": [1, 2],
+        "high": [1, 2],
+        "low": [1, 2],
+        "close": [1, 2],
+        "volume": [1, 1],
+    })
+    monkeypatch.setattr(signal_loop, "fetch_ohlcv", lambda *a, **k: df)
+
+    monkeypatch.setattr(
+        signal_loop,
+        "f2_signal",
+        lambda *a, **k: {
+            "symbol": "KRW-BBB",
+            "buy_signal": False,
+            "sell_signal": True,
+            "buy_triggers": [],
+            "sell_triggers": ["A"],
+        },
+    )
+    calls = {"sell": 0}
+    pm = signal_loop._default_executor.position_manager
+    pm.positions = [{"symbol": "KRW-BBB", "status": "open", "strategy": "A"}]
+    monkeypatch.setattr(pm, "execute_sell", lambda *a, **k: calls.__setitem__("sell", calls["sell"] + 1))
+
+    signal_loop.process_symbol("KRW-BBB")
+    assert calls["sell"] == 1
+


### PR DESCRIPTION
## Summary
- expand label creation tests for trailing-stop logic
- check trailing stop sell execution
- verify signal loop forwards signals to order executor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445c99ba6c8329809a05d71d3e3f86