### PR TITLE
Update docs for check_signals

### DIFF
--- a/doc/00_auto_upbit.md
+++ b/doc/00_auto_upbit.md
@@ -28,7 +28,12 @@ flowchart TD
 - **역할**: 최근 1분봉 데이터를 이용해 머신러닝으로 매수 가능성을 판단합니다.
 - **주요 파일**: `f2_buy_signal/02_ml_buy_signal.py`, `f2_buy_signal/01_buy_indicator.py`, `f2_buy_signal/03_buy_signal_engine/signal_engine.py`
 - **주요 함수**
-  - `check_signals(symbol)` – 예측 CSV에서 세 신호를 계산해 반환합니다.
+  - `check_signals(symbol)` – `f5_ml_pipeline/ml_data/08_pred/{symbol}_pred.csv`를 읽어 세 신호를 계산한 뒤 딕셔너리로 반환합니다.
+
+    ```python
+    check_signals("KRW-BTC")
+    # {"signal1": True, "signal2": False, "signal3": True}
+    ```
 - **로그**: `logs/f2/f2_buy_signal.log`
 
 ## 3. F3 주문 실행기

--- a/doc/02_coin_buy_signal.md
+++ b/doc/02_coin_buy_signal.md
@@ -1,6 +1,13 @@
 # 코인 매수 시그널 생성 로직
 
-본 문서는 `01_selecting_coins_to_buy.md`에서 선정된 코인을 대상으로 `f2_buy_signal.check_signals()` 함수가 어떻게 사용되는지 설명합니다.
+본 문서는 `01_selecting_coins_to_buy.md`에서 선정된 코인을 대상으로 `f2_buy_signal.check_signals()` 함수가 어떻게 사용되는지 설명합니다. 이 함수는 `f5_ml_pipeline/ml_data/08_pred/{symbol}_pred.csv` 파일을 읽어 세 가지 조건을 분석한 뒤 다음과 같은 딕셔너리를 반환합니다.
+
+```python
+signals = check_signals("KRW-BTC")
+# {"signal1": True, "signal2": True, "signal3": False}
+```
+
+세 값이 모두 `True`일 때만 실매수 대상으로 간주합니다.
 
 ## 역할
 - F2 모듈은 F5 단계의 예측 CSV를 읽어 세 가지 조건을 평가합니다.

--- a/f2_buy_signal/__init__.py
+++ b/f2_buy_signal/__init__.py
@@ -1,7 +1,18 @@
+from __future__ import annotations
+
 from importlib import import_module
+import csv
+import logging
+from pathlib import Path
 import sys
 
 _submodules = {"01_buy_indicator", "02_ml_buy_signal", "03_buy_signal_engine"}
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PRED_DIR = PROJECT_ROOT / "f5_ml_pipeline" / "ml_data" / "08_pred"
+
+logger = logging.getLogger(__name__)
+
 
 def __getattr__(name):
     if name in _submodules:
@@ -11,3 +22,46 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
 __all__ = list(_submodules)
+
+
+def reload_strategy_settings() -> None:
+    """Placeholder for compatibility."""
+    return None
+
+
+def check_signals(symbol: str) -> dict:
+    """Read prediction file for ``symbol`` and return signal flags."""
+    path = PRED_DIR / f"{symbol}_pred.csv"
+    result = {"signal1": False, "signal2": False, "signal3": False}
+    if not path.exists():
+        logger.warning("prediction file not found: %s", path)
+        return result
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            rows = list(csv.DictReader(f))
+    except Exception as exc:
+        logger.error("failed to read %s: %s", path, exc)
+        return result
+    if not rows:
+        return result
+    row = rows[-1]
+    try:
+        signal1 = bool(int(float(row.get("buy_signal", row.get("buy_prob", 0)))))
+    except Exception:
+        try:
+            signal1 = float(row.get("buy_prob", 0)) > 0.5
+        except Exception:
+            signal1 = False
+    try:
+        rsi = float(row.get("rsi14", 0))
+        signal2 = 40 < rsi < 60
+    except Exception:
+        signal2 = False
+    try:
+        ema5 = float(row.get("ema5", 0))
+        ema20 = float(row.get("ema20", 0))
+        signal3 = ema5 > ema20
+    except Exception:
+        signal3 = False
+    result.update(signal1=bool(signal1), signal2=bool(signal2), signal3=bool(signal3))
+    return result


### PR DESCRIPTION
## Summary
- document how `check_signals` loads prediction CSVs
- show example return values in docs
- restore `check_signals` helper for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446fcd4b7c83299956b87cdf7d0976