### PR TITLE
Remove unused ML strategy params file

### DIFF
--- a/config/f5_f5_strategy_params.json
+++ b/config/f5_f5_strategy_params.json
@@ -1,6 +1,0 @@
-{
-  "M-BREAK": {"min_bars": 20},
-  "P-PULL": {"min_bars": 20},
-  "T-FLOW": {"min_bars": 20},
-  "G-REV": {"min_bars": 20}
-}

--- a/doc/config.md
+++ b/doc/config.md
@@ -82,6 +82,6 @@ Defaults are `0.18`, `2`, `'OFF'`, `180`, `0.3` and `1.0` respectively.
 configuration. The trailing-stop flag is converted to `TRAILING_STOP_ENABLED`
 for `PositionManager`.
 ## f5_f5_strategy_params.json
-Default hyperparameters for each strategy used by the ML pipeline.
+This file has been removed. Strategy hyperparameters are now defined directly in the code.
 
 


### PR DESCRIPTION
## Summary
- delete deprecated `f5_f5_strategy_params.json`
- document the removal in `config.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447db4d814832980ce82c2c7b778ea